### PR TITLE
Setup Terraform for Linode Cloud & Fix missing terraform init

### DIFF
--- a/.github/workflows/terraform-linode-cd.yaml
+++ b/.github/workflows/terraform-linode-cd.yaml
@@ -7,6 +7,10 @@
 name: "CD/Terraform: Linode Cloud"
 on:
   push:
+    paths:
+      - "terraform/linode/**"
+    branches:
+      - main
 jobs:
   terraform-apply:
     name: "Terraform Apply: Linode Cloud"

--- a/.github/workflows/terraform-linode-cd.yaml
+++ b/.github/workflows/terraform-linode-cd.yaml
@@ -21,5 +21,7 @@ jobs:
         with:
           terraform_version: 1.0.1
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+      - name: "Terraform Init"
+        run: terraform init
       - name: "Terraform Apply"
         run: terraform apply -auto-approve

--- a/.github/workflows/terraform-linode-cd.yaml
+++ b/.github/workflows/terraform-linode-cd.yaml
@@ -6,10 +6,6 @@
 
 on:
   push:
-    paths:
-      - "terraform/linode/**"
-    branches:
-      - main
 jobs:
   terraform-apply:
     name: "Terraform Apply: Linode Cloud"

--- a/.github/workflows/terraform-linode-cd.yaml
+++ b/.github/workflows/terraform-linode-cd.yaml
@@ -1,19 +1,18 @@
 #
 # nimbus
 # terraform linode cloud
-# continous integration pipeline
+# continous deployment pipeline
 #
 
 on:
   push:
     paths:
       - "terraform/linode/**"
-  pull_request:
-    paths:
-      - "terraform/linode/**"
+    branches:
+      - main
 jobs:
-  terraform-lint-plan:
-    name: "Terraform Lint & Plan: Linode Cloud"
+  terraform-apply:
+    name: "Terraform Apply: Linode Cloud"
     runs-on: ubuntu-20.04
     defaults:
       run:
@@ -25,11 +24,5 @@ jobs:
         with:
           terraform_version: 1.0.1
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
-      - name: "Terraform Fmt Check"
-        run: terraform fmt -check
-      - name: "Terraform Init"
-        run: terraform init
-      - name: "Terraform Validate"
-        run: terraform validate -no-color
-      - name: "Terraform Plan"
-        run: terraform plan
+      - name: "Terraform Apply"
+        run: terraform apply -auto-approve

--- a/.github/workflows/terraform-linode-cd.yaml
+++ b/.github/workflows/terraform-linode-cd.yaml
@@ -1,9 +1,10 @@
 #
 # nimbus
 # terraform linode cloud
-# continous deployment pipeline
+# continuous deployment pipeline
 #
 
+name: "CD/Terraform: Linode Cloud"
 on:
   push:
 jobs:

--- a/.github/workflows/terraform-linode-ci.yaml
+++ b/.github/workflows/terraform-linode-ci.yaml
@@ -6,8 +6,6 @@
 
 on:
   push:
-    paths:
-      - "terraform/linode/**"
 jobs:
   terraform-lint-plan:
     name: "Terraform Lint & Plan: Linode Cloud"

--- a/.github/workflows/terraform-linode-ci.yaml
+++ b/.github/workflows/terraform-linode-ci.yaml
@@ -4,6 +4,7 @@
 # continous integration pipeline
 #
 
+name: "CI/Terraform: Linode Cloud"
 on:
   push:
 jobs:

--- a/.github/workflows/terraform-linode-ci.yaml
+++ b/.github/workflows/terraform-linode-ci.yaml
@@ -7,6 +7,8 @@
 name: "CI/Terraform: Linode Cloud"
 on:
   push:
+    paths:
+      - "terraform/linode/**"
 jobs:
   terraform-lint-plan:
     name: "Terraform Lint & Plan: Linode Cloud"

--- a/.github/workflows/terraform-linode-ci.yaml
+++ b/.github/workflows/terraform-linode-ci.yaml
@@ -8,9 +8,6 @@ on:
   push:
     paths:
       - "terraform/linode/**"
-  pull_request:
-    paths:
-      - "terraform/linode/**"
 jobs:
   terraform-lint-plan:
     name: "Terraform Lint & Plan: Linode Cloud"

--- a/.github/workflows/terraform-linode-ci.yaml
+++ b/.github/workflows/terraform-linode-ci.yaml
@@ -1,0 +1,32 @@
+#
+# nimbus
+# terraform linode cloud
+# continous integration pipeline
+#
+
+on:
+  push:
+    paths:
+      - "terraform/linode/**"
+  pull_request:
+    paths:
+      - "terraform/linode/**"
+jobs:
+  terraform-lint-plan:
+    name: "Terraform Lint & Plan: Linode Cloud"
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: "Setup Terraform CLI"
+        uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 1.0.1
+          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+      - name: "Terraform Fmt Check"
+        run: terraform fmt -check
+      - name: "Terraform Init"
+        run: terraform init
+      - name: "Terraform Validate"
+        run: terraform validate -no-color
+      - name: "Terraform Plan"
+        run: terraform plan

--- a/.github/workflows/terraform-wasabi-cd.yaml
+++ b/.github/workflows/terraform-wasabi-cd.yaml
@@ -6,10 +6,6 @@
 
 on:
   push:
-    paths:
-      - "terraform/wasabi/**"
-    branches:
-      - main
 jobs:
   terraform-apply:
     name: "Terraform Apply: Wasabi Cloud Storage"

--- a/.github/workflows/terraform-wasabi-cd.yaml
+++ b/.github/workflows/terraform-wasabi-cd.yaml
@@ -21,5 +21,7 @@ jobs:
         with:
           terraform_version: 1.0.1
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+      - name: "Terraform Init"
+        run: terraform init
       - name: "Terraform Apply"
         run: terraform apply -auto-approve

--- a/.github/workflows/terraform-wasabi-cd.yaml
+++ b/.github/workflows/terraform-wasabi-cd.yaml
@@ -7,6 +7,10 @@
 name: "CD/Terraform: Wasabi Cloud Storage"
 on:
   push:
+    paths:
+      - "terraform/wasabi/**"
+    branches:
+      - main
 jobs:
   terraform-apply:
     name: "Terraform Apply: Wasabi Cloud Storage"

--- a/.github/workflows/terraform-wasabi-cd.yaml
+++ b/.github/workflows/terraform-wasabi-cd.yaml
@@ -4,6 +4,7 @@
 # continous deployment pipeline
 #
 
+name: "CD/Terraform: Wasabi Cloud Storage"
 on:
   push:
 jobs:

--- a/.github/workflows/terraform-wasabi-ci.yaml
+++ b/.github/workflows/terraform-wasabi-ci.yaml
@@ -7,6 +7,8 @@
 name: "CI/Terraform: Wasabi Cloud Storage"
 on:
   push:
+    paths:
+      - "terraform/wasabi/**"
 jobs:
   terraform-lint-plan:
     name: "Terraform Lint & Plan: Wasabi Cloud Storage "

--- a/.github/workflows/terraform-wasabi-ci.yaml
+++ b/.github/workflows/terraform-wasabi-ci.yaml
@@ -4,6 +4,7 @@
 # continous integration pipeline
 #
 
+name: "CI/Terraform: Wasabi Cloud Storage"
 on:
   push:
 jobs:

--- a/.github/workflows/terraform-wasabi-ci.yaml
+++ b/.github/workflows/terraform-wasabi-ci.yaml
@@ -6,8 +6,6 @@
 
 on:
   push:
-    paths:
-      - "terraform/wasabi/**"
 jobs:
   terraform-lint-plan:
     name: "Terraform Lint & Plan: Wasabi Cloud Storage "

--- a/terraform/linode/.terraform.lock.hcl
+++ b/terraform/linode/.terraform.lock.hcl
@@ -1,0 +1,23 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/linode/linode" {
+  version     = "1.19.1"
+  constraints = "1.19.1"
+  hashes = [
+    "h1:UNXJmnbYmZuwMl1q8O/ix2NcyvEI29cAg91ZOjb1qXU=",
+    "zh:1b9f22c1882b1451492341ef28d6776f606a244e8a58340c21dd6949015a229d",
+    "zh:2557f3415f85c9570e44fa7f147269d12c1e4bf32b5b21b09a347dcf574967de",
+    "zh:414eac8b55c4db6e4c44702ee3b99e4912bc59c213c4c881309b7c7434977644",
+    "zh:436005c12b777a54f0d713a345f30e831e9110a08a464a0178cf64438ad95b08",
+    "zh:441358a02bc23f16830c0665a51508edf46a52cf348b69adbd8b6614fe8d4506",
+    "zh:487249165132fe777071dfffaae04f14087c966f67e813d01c770b8cf628ed00",
+    "zh:510c500b8dd0639b1e54297664d183498cae20d3ebf7433c258522b462dd17e0",
+    "zh:57e80c659478185d0adc03764c28cb950e2ae1ca488b296a8a5d6a661a1b55c5",
+    "zh:8a487493cdc40081842c5d95cf187fb1e4ce3f8e0ed17b059ecf536418809cd4",
+    "zh:afa4b850893aad1e1e90c46f44fdc21cc906ad2417b8d1575bd94a12b9e25be8",
+    "zh:cdaed1da0654cb3d6d644af0b7098adcb361c7491ceaa831e322575fa1cbd790",
+    "zh:e1d4a03ed421d4e05c8e4a5c5d15f45e1bdd0e2f51c9dba0dc3d051996684a31",
+    "zh:f5c4673c6968d6b58f4530e623c4dd7240491ce6acfef57d074177f1511ea76f",
+  ]
+}

--- a/terraform/linode/main.tf
+++ b/terraform/linode/main.tf
@@ -1,0 +1,26 @@
+#
+# nimbus
+# terraform deploy for linode cloud
+#
+
+terraform {
+  backend "remote" {
+    organization = "mrzzy-co"
+
+    workspaces {
+      name = "nimbus-terraform-linode"
+    }
+  }
+  required_providers {
+    linode = {
+      source  = "linode/linode"
+      version = "1.19.1"
+    }
+  }
+  required_version = "1.0.1"
+}
+
+## Providers ##
+provider "linode" {
+  token =  var.linode_token
+}

--- a/terraform/linode/main.tf
+++ b/terraform/linode/main.tf
@@ -22,5 +22,5 @@ terraform {
 
 ## Providers ##
 provider "linode" {
-  token =  var.linode_token
+  token = var.linode_token
 }

--- a/terraform/linode/variables.tf
+++ b/terraform/linode/variables.tf
@@ -5,7 +5,7 @@
 #
 
 variable "linode_token" {
-  type = string
-  sensitive = true
+  type        = string
+  sensitive   = true
   description = "Linode Personal Access Token for authenticating with Linode"
 }

--- a/terraform/linode/variables.tf
+++ b/terraform/linode/variables.tf
@@ -1,0 +1,11 @@
+#
+# nimbus
+# terraform deploy for linode cloud
+# input variables
+#
+
+variable "linode_token" {
+  type = string
+  sensitive = true
+  description = "Linode Personal Access Token for authenticating with Linode"
+}


### PR DESCRIPTION
Setup Terraform for Linode Cloud:
* Setup linode provider for deploying Linode infrastructure via `terraform`
* Adds Github Actions CI/CD pipelines for automating deployment with `terraform`

Fix missing `terraform init`:
- Fix missing `terraform init` step for Terraform CD pipelines (both targeting Wasabi & Linode).