### PR TITLE
Deploy Linode LKE Cluster in Singapore Region with Terraform & Add SSH Key

### DIFF
--- a/terraform/linode/main.tf
+++ b/terraform/linode/main.tf
@@ -24,3 +24,9 @@ terraform {
 provider "linode" {
   token = var.linode_token
 }
+
+## Resources ##
+resource "linode_sshkey" "mrzzy_ed25519" {
+  label = "mrzzy_ed25519"
+  ssh_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBrfd982D9iQVTe2VecUncbgysh/XsZb4YyOhCSSAAtr zzy"
+}

--- a/terraform/linode/main.tf
+++ b/terraform/linode/main.tf
@@ -27,6 +27,23 @@ provider "linode" {
 
 ## Resources ##
 resource "linode_sshkey" "mrzzy_ed25519" {
-  label = "mrzzy_ed25519"
+  label   = "${var.prefix}-mrzzy-ed25519"
   ssh_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBrfd982D9iQVTe2VecUncbgysh/XsZb4YyOhCSSAAtr zzy"
+}
+
+resource "linode_lke_cluster" "singapore" {
+  label       = "${var.prefix}-singapore-k8s"
+  region      = "ap-south"
+  k8s_version = "1.21"
+
+  # default node pool: 1vcpu, 2gb
+  pool {
+    type  = "g6-standard-1"
+    count = 1
+  }
+
+  tags = [
+    "terraform",
+    "sgp"
+  ]
 }

--- a/terraform/linode/outputs.tf
+++ b/terraform/linode/outputs.tf
@@ -1,0 +1,15 @@
+#
+# nimbus
+# terraform deploy for linode cloud
+# output
+#
+
+output "k8s_singapore_id" {
+  value       = linode_lke_cluster.singapore.id
+  description = "ID of Linode LKE Cluster in Singapore"
+}
+
+output "k8s_singapore_status" {
+  value       = linode_lke_cluster.singapore.status
+  description = "Status of Linode LKE Cluster in Singapore"
+}

--- a/terraform/linode/variables.tf
+++ b/terraform/linode/variables.tf
@@ -9,3 +9,8 @@ variable "linode_token" {
   sensitive   = true
   description = "Linode Personal Access Token for authenticating with Linode"
 }
+
+variable "prefix" {
+  type        = string
+  description = "Prefix to attach to labels of created resources"
+}


### PR DESCRIPTION
Deploy Linode LKE Cluster in Singapore Region with Terraform:
- Added "singapore" LKE cluster Terraform resource:
  - Runs a nodepool with 1 `g6-standard-1` instance.
- Adds @mrzzy's ed25519 ssh public key.