### PR TITLE
Deploy ingress-nginx as ingress provider via ArgoCD

### DIFF
--- a/.github/workflows/bootstrap-argocd-cd.yaml
+++ b/.github/workflows/bootstrap-argocd-cd.yaml
@@ -16,9 +16,6 @@ jobs:
   deploy-argocd:
     name: "Deploy ArgoCD on Linode k8s"
     runs-on: ubuntu-20.04
-    defaults:
-      run:
-        working-directory: "terraform/linode"
     env:
       KUBECONFIG: kubeconfig.yaml
       ARGOCD_YAML: https://raw.githubusercontent.com/argoproj/argo-cd/v2.0.4/manifests/install.yaml
@@ -31,10 +28,12 @@ jobs:
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
           terraform_wrapper: false
       - name: "Get k8s Cluster Kubeconfig from Terraform"
+        working-directory: "terraform/linode"
         run: |
           terraform init
           terraform apply -refresh-only -auto-approve
-          terraform output -raw k8s_singapore_kubeconfig | base64 -d >$KUBECONFIG
+          # write kubeconfig to project root
+          terraform output -raw k8s_singapore_kubeconfig | base64 -d >../../$KUBECONFIG
       - name: "Create ArgoCD namespace on k8s if it does not exist"
         run: kubectl create namespace argocd --dry-run=client -o yaml | kubectl apply -f -
       - name: "Dry Run: Apply ArgoCD manifests on k8s"

--- a/.github/workflows/bootstrap-argocd-cd.yaml
+++ b/.github/workflows/bootstrap-argocd-cd.yaml
@@ -7,8 +7,8 @@
 name: "CD: Deploy ArgoCD & CRDs on Linode k8s"
 on:
   push:
-    #branches:
-    #  - main
+    branches:
+      - main
     paths:
       - ".github/workflows/bootstrap-argocd-cd.yaml"
       - "k8s/argocd/**"

--- a/.github/workflows/bootstrap-argocd-cd.yaml
+++ b/.github/workflows/bootstrap-argocd-cd.yaml
@@ -7,8 +7,8 @@
 name: "CD: Deploy ArgoCD on Linode k8s"
 on:
   push:
-    branches:
-      - main
+    #branches:
+    #  - main
     paths:
       - ".github/workflows/bootstrap-argocd-cd.yaml"
       - "k8s/argocd/**"

--- a/.github/workflows/bootstrap-argocd-cd.yaml
+++ b/.github/workflows/bootstrap-argocd-cd.yaml
@@ -40,5 +40,7 @@ jobs:
         run: kubectl apply --dry-run=server -n argocd -f $ARGOCD_YAML
       - name: "Apply ArgoCD manifests on k8s"
         run: kubectl apply -n argocd -f $ARGOCD_YAML
+      - name: "Dry Run: Apply ArgoCD CRD manifests on k8s"
+        run: kubectl apply --dry-run=server -n argocd -f k8s/argocd 
       - name: "Apply ArgoCD CRD manifests on k8s"
         run: kubectl apply -n argocd -f k8s/argocd 

--- a/.github/workflows/bootstrap-argocd-cd.yaml
+++ b/.github/workflows/bootstrap-argocd-cd.yaml
@@ -4,7 +4,7 @@
 # Continuous Deployment pipeline
 #
 
-name: "CD: Deploy ArgoCD on Linode k8s"
+name: "CD: Deploy ArgoCD & CRDs on Linode k8s"
 on:
   push:
     #branches:

--- a/.github/workflows/bootstrap-argocd-cd.yaml
+++ b/.github/workflows/bootstrap-argocd-cd.yaml
@@ -11,6 +11,7 @@ on:
       - main
     paths:
       - ".github/workflows/bootstrap-argocd-cd.yaml"
+      - "k8s/argocd/**"
 jobs:
   deploy-argocd:
     name: "Deploy ArgoCD on Linode k8s"
@@ -40,3 +41,5 @@ jobs:
         run: kubectl apply --dry-run=server -n argocd -f $ARGOCD_YAML
       - name: "Apply ArgoCD manifests on k8s"
         run: kubectl apply -n argocd -f $ARGOCD_YAML
+      - name: "Apply ArgoCD CRD manifests on k8s"
+        run: kubectl apply -n argocd -f k8s/argocd 

--- a/k8s/argocd/ingress-nginx.yaml
+++ b/k8s/argocd/ingress-nginx.yaml
@@ -1,0 +1,19 @@
+#
+# nimbus
+# argocd app to deploy ingress-nginx
+#
+
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ingress-nginx
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/mrzzy/nimbus.git
+    targetRevision: HEAD
+    path: k8s/kustomize/ingress-nginx
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: ingress-nginx

--- a/k8s/argocd/ingress-nginx.yaml
+++ b/k8s/argocd/ingress-nginx.yaml
@@ -17,3 +17,5 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: ingress-nginx
+  syncPolicy:
+    automated: {}

--- a/k8s/argocd/project.yaml
+++ b/k8s/argocd/project.yaml
@@ -1,0 +1,19 @@
+#
+# nimbus
+# argocd project
+#
+
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: nimbus
+  namespace: argocd
+  # Finalizer that ensures that project is not deleted until it is not referenced by any application
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  description: "Project Nimbus https://github.com/mrzzy/nimbus"
+  sourceRepos:
+    - "*"
+  destinations:
+    - server:  https://kubernetes.default.svc

--- a/k8s/kustomize/ingress-nginx/kustomization.yml
+++ b/k8s/kustomize/ingress-nginx/kustomization.yml
@@ -3,6 +3,6 @@
 # k8s: ingress
 #
 
-# deploy nginx ingress
+# deploy ingress nginx for ingress support
 resources:
   - https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v0.47.0/deploy/static/provider/cloud/deploy.yaml


### PR DESCRIPTION
Deploy ingress-nginx as ingress provider via ArgoCD:
- Add `kustomize` configuration to generate manfest for deploying ingress-nginx.
- Add `nimbus` ArgoCD project to track all applications deployed from this repository.
- Add ArgoCD Application to register ingress-nginx with ArgoCD
- Updated ArgoCD Github Actions CD pipeline to also automatically deploy ArgoCD CRDs as well.