### PR TITLE
Clean up K8s Kustomize Deployments 

### DIFF
--- a/k8s/kustomize/cert-manager/kustomization.yml
+++ b/k8s/kustomize/cert-manager/kustomization.yml
@@ -4,6 +4,8 @@
 #
 
 # deploy cert manager for digital certificate management
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
 - https://github.com/jetstack/cert-manager/releases/download/v1.4.0/cert-manager.yaml
 - issuers/cluster-staging.yaml

--- a/k8s/kustomize/elastic-cloud/kustomization.yaml
+++ b/k8s/kustomize/elastic-cloud/kustomization.yaml
@@ -3,6 +3,8 @@
 # elastic cloud operator kustomization
 #
 
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
 # deploy elastic cloud operator to deploy elastic cloud components via CRDs
 - https://download.elastic.co/downloads/eck/1.6.0/all-in-one.yaml

--- a/k8s/kustomize/fluent-bit/kustomization.yaml
+++ b/k8s/kustomize/fluent-bit/kustomization.yaml
@@ -3,6 +3,8 @@
 # fluent-bit log collection
 #
 
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
 - namespace.yaml
 - https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-service-account.yaml
@@ -11,13 +13,10 @@ resources:
 - https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/output/elasticsearch/fluent-bit-configmap.yaml
 - https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/output/elasticsearch/fluent-bit-ds.yaml
 - elastic-creds-sealed.yaml
-
 namespace: logging
-
 images:
 - name: fluent/fluent-bit
   newTag: 1.8.1
-
 patches:
 # patch to point fluentd at the elasticsearch service
 - target:

--- a/k8s/kustomize/ingress-nginx/kustomization.yml
+++ b/k8s/kustomize/ingress-nginx/kustomization.yml
@@ -4,5 +4,7 @@
 #
 
 # deploy ingress nginx for ingress support
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
   - https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v0.47.0/deploy/static/provider/cloud/deploy.yaml

--- a/k8s/kustomize/kube-prometheus/kustomization.yaml
+++ b/k8s/kustomize/kube-prometheus/kustomization.yaml
@@ -94,7 +94,6 @@ resources:
 patches:
 - target:
     group: monitoring.coreos.com
-    version:  v1
     kind: AlertManager
     labelSelector: "app.kubernetes.io/part-of=kube-prometheus"
   patch: |-
@@ -103,7 +102,6 @@ patches:
       value:  1
 - target:
     group: monitoring.coreos.com
-    version:  v1
     kind: Prometheus
     labelSelector: "app.kubernetes.io/part-of=kube-prometheus"
   patch: |-
@@ -112,7 +110,6 @@ patches:
       value:  1
 - target:
     group: apps
-    version: v1
     kind: Deployment
     name: prometheus-adapter
     labelSelector: "app.kubernetes.io/part-of=kube-prometheus"
@@ -123,7 +120,6 @@ patches:
 # config RBAC to allow prometheus to scrap all namespaces
 - target:
     group: rbac.authorization.k8s.io
-    version: v1
     kind: ClusterRole
     name: prometheus-k8s
     labelSelector: "app.kubernetes.io/part-of=kube-prometheus"

--- a/k8s/kustomize/kube-prometheus/kustomization.yaml
+++ b/k8s/kustomize/kube-prometheus/kustomization.yaml
@@ -4,6 +4,8 @@
 #
 #
 
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
 - https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/release-0.8/manifests/setup/0namespace-namespace.yaml
 - https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/release-0.8/manifests/setup/prometheus-operator-0alertmanagerConfigCustomResourceDefinition.yaml

--- a/k8s/kustomize/sealed-secrets/kustomization.yml
+++ b/k8s/kustomize/sealed-secrets/kustomization.yml
@@ -3,9 +3,10 @@
 # sealed-secrets kustomization
 #
 
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
 - https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.16.0/controller.yaml
-
 patches:
 # configures sealed secret controller to output status of SealedSecret CRDs
 # required by ArgoCD to verify the status of SealedSecret CRDs

--- a/k8s/kustomize/sealed-secrets/kustomization.yml
+++ b/k8s/kustomize/sealed-secrets/kustomization.yml
@@ -11,7 +11,6 @@ patches:
 # required by ArgoCD to verify the status of SealedSecret CRDs
 - target:
     group: apps
-    version: v1
     kind: Deployment
     name: sealed-secrets-controller
   patch: |-


### PR DESCRIPTION
Fixes  #12 


Clean up K8s Kustomize Deployments
- Remove version matching in patches in Kustomizations.
- Add `apiVersion` and `kind: Kustomization` to all under `k8s/kustomize`.