### PR TITLE
Use .secret-baseline to explicitly whitelist sealed secrets from detect-secrets

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,8 +13,3 @@ repos:
     args:
     - '--baseline'
     - '.secrets.baseline'
-    - '--disable-plugin'
-    - 'KeywordDetector'
-    - '--exclude-files'
-    # prevent false positive on sealed secrets
-    - '.*sealed.yaml'

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,10 +1,5 @@
 {
-  "custom_plugin_paths": [],
-  "exclude": {
-    "files": null,
-    "lines": null
-  },
-  "generated_at": "2021-07-09T04:56:20Z",
+  "generated_at": "2021-07-14T05:20:03Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -13,8 +8,8 @@
       "name": "ArtifactoryDetector"
     },
     {
-      "base64_limit": 4.5,
-      "name": "Base64HighEntropyString"
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
     },
     {
       "name": "BasicAuthDetector"
@@ -23,8 +18,8 @@
       "name": "CloudantDetector"
     },
     {
-      "hex_limit": 3,
-      "name": "HexHighEntropyString"
+      "name": "HexHighEntropyString",
+      "limit": 3
     },
     {
       "name": "IbmCloudIamDetector"
@@ -58,10 +53,79 @@
       "name": "TwilioKeyDetector"
     }
   ],
-  "results": {},
-  "version": "0.14.3",
-  "word_list": {
-    "file": null,
-    "hash": null
-  }
+  "results": {
+    "k8s/kustomize/elastic-cloud/elastic-filerealm-sealed.yaml": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "k8s/kustomize/elastic-cloud/elastic-filerealm-sealed.yaml",
+        "hashed_secret": "dfa62b33abda72e8e29184cbd13f3f00904a7cd5",
+        "is_verified": false,
+        "line_number": 9,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "k8s/kustomize/elastic-cloud/elastic-filerealm-sealed.yaml",
+        "hashed_secret": "e105038cc59be15208695a8768e7466288b56c9d",
+        "is_verified": false,
+        "line_number": 10,
+        "is_secret": false
+      }
+    ],
+    "k8s/kustomize/fluent-bit/elastic-creds-sealed.yaml": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "k8s/kustomize/fluent-bit/elastic-creds-sealed.yaml",
+        "hashed_secret": "597c5e9c916ee4786923a2caf3d5bab7b9a1e987",
+        "is_verified": false,
+        "line_number": 9,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "k8s/kustomize/fluent-bit/elastic-creds-sealed.yaml",
+        "hashed_secret": "a5b6bf50fb9b2ff04290f7701a35cc074570efd8",
+        "is_verified": false,
+        "line_number": 10,
+        "is_secret": false
+      }
+    ]
+  },
+  "version": "1.1.0",
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    }
+  ]
 }


### PR DESCRIPTION
Fixes #10 

Use .secret-baseline to explicitly whitelist sealed secrets from detect-secrets:
- Explicitly mark sealed-secrets as non secrets in .secrets.baseline.
- Remove flags passed by pre-commit to detect-secrets.