### PR TITLE
Deploy Tiddlywiki on Linode K8s

### DIFF
--- a/k8s/argocd/apps/tiddlywiki.yaml
+++ b/k8s/argocd/apps/tiddlywiki.yaml
@@ -1,0 +1,19 @@
+#
+# nimbus
+# argocd app to deploy tiddlywiki
+#
+
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: tiddlywiki
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/mrzzy/nimbus.git
+    targetRevision: HEAD
+    path: k8s/kustomize/tiddlywiki
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: tiddlywiki

--- a/k8s/kustomize/keycloak/kustomization.yaml
+++ b/k8s/kustomize/keycloak/kustomization.yaml
@@ -3,9 +3,11 @@
 # kustomization to deploy keycloak
 #
 
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 namespace: keycloak
 resources:
-- github.com/keycloak/keycloak-operator/deploy?ref=15.0.0
+  #- github.com/keycloak/keycloak-operator/deploy?ref=15.0.0
 - keycloak.yaml
 - ingress.yaml
-- realms/tiddlywiki.yaml
+- realms/tiddlywiki

--- a/k8s/kustomize/keycloak/kustomization.yaml
+++ b/k8s/kustomize/keycloak/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
 - github.com/keycloak/keycloak-operator/deploy?ref=15.0.0
 - keycloak.yaml
 - ingress.yaml
+- realms/tiddlywiki.yaml

--- a/k8s/kustomize/keycloak/realms/tiddlywiki.yaml
+++ b/k8s/kustomize/keycloak/realms/tiddlywiki.yaml
@@ -1,0 +1,21 @@
+#
+# nimbus
+# tiddlywiki deploy
+# keycloak realm
+#
+
+apiVersion: keycloak.org/v1alpha1
+kind: KeycloakRealm
+metadata:
+  name: tiddlywiki
+spec:
+  realm:
+    id: "tiddlywiki"
+    realm: "tiddlywiki"
+    enabled: True
+    displayName: "TiddlyWiki"
+  # select keycloak instance to create realm in
+  instanceSelector:
+    matchLabels:
+      app: keycloak
+      app.kubernetes.io/instance: keycloak

--- a/k8s/kustomize/keycloak/realms/tiddlywiki/kustomization.yaml
+++ b/k8s/kustomize/keycloak/realms/tiddlywiki/kustomization.yaml
@@ -5,6 +5,7 @@
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+# keycloak CRDs must be deployed in the same namespace as the keycloak deployment
 namespace: keycloak
 commonLabels:
   app: tiddlywiki

--- a/k8s/kustomize/keycloak/realms/tiddlywiki/kustomization.yaml
+++ b/k8s/kustomize/keycloak/realms/tiddlywiki/kustomization.yaml
@@ -1,0 +1,14 @@
+#
+# nimbus
+# kustomization to deploy keycloak realm for tiddlywiki deploy
+#
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: keycloak
+commonLabels:
+  app: tiddlywiki
+  deployed-for: tiddlywiki
+resources:
+- realm.yaml
+- oauth-client.yaml

--- a/k8s/kustomize/keycloak/realms/tiddlywiki/oauth-client.yaml
+++ b/k8s/kustomize/keycloak/realms/tiddlywiki/oauth-client.yaml
@@ -24,3 +24,4 @@ spec:
       - "https://wiki.mrzzy.co/oauth2/callback"
     defaultClientScopes:
       - email
+      - profile

--- a/k8s/kustomize/keycloak/realms/tiddlywiki/oauth-client.yaml
+++ b/k8s/kustomize/keycloak/realms/tiddlywiki/oauth-client.yaml
@@ -22,3 +22,5 @@ spec:
     # valid urls to redirect oauth authorization codes to
     redirectUris:
       - "https://wiki.mrzzy.co/oauth2/callback"
+    defaultClientScopes:
+      - email

--- a/k8s/kustomize/keycloak/realms/tiddlywiki/oauth-client.yaml
+++ b/k8s/kustomize/keycloak/realms/tiddlywiki/oauth-client.yaml
@@ -17,9 +17,6 @@ spec:
   client:
     # name of the client
     clientId: tiddlywiki-oauth-client
-    # suffix of the secret that stores the oauth2 client credentials
-    # actual secret name is prefixed with 'keycloak-client-secret'
-    secret: tiddlywiki-oauth # pragma: allowlist secret
     # enable standard oauth2 flow
     standardFlowEnabled: true
     # valid urls to redirect oauth authorization codes to

--- a/k8s/kustomize/keycloak/realms/tiddlywiki/oauth-client.yaml
+++ b/k8s/kustomize/keycloak/realms/tiddlywiki/oauth-client.yaml
@@ -1,0 +1,27 @@
+#
+# nimbus
+# keycloak client
+# used by oauth-proxy to provide authentication for tiddlywiki
+#
+
+apiVersion: keycloak.org/v1alpha1
+kind: KeycloakClient
+metadata:
+  name: tiddlywiki-oauth
+  labels:
+spec:
+  realmSelector:
+     matchLabels:
+      app: tiddlywiki
+      deployed-for: tiddlywiki
+  client:
+    # name of the client
+    clientId: tiddlywiki-oauth-client
+    # suffix of the secret that stores the oauth2 client credentials
+    # actual secret name is prefixed with 'keycloak-client-secret'
+    secret: tiddlywiki-oauth # pragma: allowlist secret
+    # enable standard oauth2 flow
+    standardFlowEnabled: true
+    # valid urls to redirect oauth authorization codes to
+    redirectUris:
+      - "https://wiki.mrzzy.co/oauth2/callback"

--- a/k8s/kustomize/keycloak/realms/tiddlywiki/realm.yaml
+++ b/k8s/kustomize/keycloak/realms/tiddlywiki/realm.yaml
@@ -1,19 +1,21 @@
 #
 # nimbus
-# tiddlywiki deploy
-# keycloak realm
+# keycloak realm for tiddlywiki
 #
 
 apiVersion: keycloak.org/v1alpha1
 kind: KeycloakRealm
 metadata:
   name: tiddlywiki
+  labels:
+    app: tiddlywiki
 spec:
   realm:
     id: "tiddlywiki"
     realm: "tiddlywiki"
-    enabled: True
+    enabled: true
     displayName: "TiddlyWiki"
+    bruteForceProtected: true
   # select keycloak instance to create realm in
   instanceSelector:
     matchLabels:

--- a/k8s/kustomize/tiddlywiki/deployment.yaml
+++ b/k8s/kustomize/tiddlywiki/deployment.yaml
@@ -64,6 +64,7 @@ spec:
             - "--redeem-url=https://keycloak.mrzzy.co/auth/realms/tiddlywiki/protocol/openid-connect/token"
             - "--profile-url=https://keycloak.mrzzy.co/auth/realms/tiddlywiki/protocol/openid-connect/userinfo"
             - "--validate-url=https://keycloak.mrzzy.co/auth/realms/tiddlywiki/protocol/openid-connect/userinfo"
+            - "--scope=email"
               # allow all emails from all domains to authenticate
             - "--email-domain=*"
           readinessProbe:

--- a/k8s/kustomize/tiddlywiki/deployment.yaml
+++ b/k8s/kustomize/tiddlywiki/deployment.yaml
@@ -1,6 +1,5 @@
 #
-# admin
-# do k8s sg cluster definitions
+# nimbus
 # tiddlywiki
 #
 

--- a/k8s/kustomize/tiddlywiki/deployment.yaml
+++ b/k8s/kustomize/tiddlywiki/deployment.yaml
@@ -13,12 +13,12 @@ spec:
     spec:
       containers:
         - name: tiddlywiki-server
-          image: tiddlywiki-node
+          image: tiddlywiki
           imagePullPolicy: Always
           volumeMounts:
             - mountPath: /wiki
               name: tiddlywiki-wiki
-              # subPath required as tiddlywiki-node image expects an empty dir
+              # subPath required as tiddlywiki image expects an empty dir
               subPath: tiddlywiki
           ports:
             - name: tiddlywiki-http

--- a/k8s/kustomize/tiddlywiki/deployment.yaml
+++ b/k8s/kustomize/tiddlywiki/deployment.yaml
@@ -41,4 +41,4 @@ spec:
       volumes:
         - name: tiddlywiki-wiki
           persistentVolumeClaim:
-            claimName: tiddlywiki-wiki-pvc
+            claimName: tiddlywiki

--- a/k8s/kustomize/tiddlywiki/deployment.yaml
+++ b/k8s/kustomize/tiddlywiki/deployment.yaml
@@ -12,7 +12,7 @@ spec:
   template:
     spec:
       containers:
-        - name: tiddlywiki-server
+        - name: tiddlywiki
           image: tiddlywiki
           imagePullPolicy: Always
           volumeMounts:
@@ -28,13 +28,56 @@ spec:
           readinessProbe:
             initialDelaySeconds: 10
             failureThreshold: 1
-            tcpSocket:
+            httpGet:
               port: tiddlywiki-http
+              path: /
           livenessProbe:
             initialDelaySeconds: 10
             failureThreshold: 1
-            tcpSocket:
+            httpGet:
               port: tiddlywiki-http
+              path: /
+        # sidecar to provide oauth2 authentication to tiddlywiki
+        - name: oauth2-proxy
+          image: oauth2-proxy
+          envFrom:
+            - secretRef:
+                name: tiddlywiki-oauth2
+          ports:
+            - name: oauth2-http
+              containerPort: 4180
+            - name: oauth2-metrics
+              containerPort: 4181
+          command:
+            - "/bin/oauth2-proxy"
+            - "--http-address=http://0.0.0.0:4180"
+            - "--metrics-address=http://0.0.0.0:4181"
+              # proxy traffic to tiddlywiki container
+            - "--upstream=http://localhost:8080"
+              # required as traiffic is reverse proxied from ingress-nginx
+            - "--reverse-proxy=true"
+              # passes username as X-Forwarded-User header
+            - "--pass-user-headers=true"
+              # keycloak oauth2 config
+            - "--provider=keycloak"
+            - "--login-url=https://keycloak.mrzzy.co/auth/realms/tiddlywiki/protocol/openid-connect/auth"
+            - "--redeem-url=https://keycloak.mrzzy.co/auth/realms/tiddlywiki/protocol/openid-connect/token"
+            - "--profile-url=https://keycloak.mrzzy.co/auth/realms/tiddlywiki/protocol/openid-connect/userinfo"
+            - "--validate-url=https://keycloak.mrzzy.co/auth/realms/tiddlywiki/protocol/openid-connect/userinfo"
+              # allow all emails from all domains to authenticate
+            - "--email-domain=*"
+          readinessProbe:
+            initialDelaySeconds: 10
+            failureThreshold: 1
+            httpGet:
+              port: oauth2-http
+              path: /ping
+          livenessProbe:
+            initialDelaySeconds: 10
+            failureThreshold: 1
+            httpGet:
+              port: oauth2-http
+              path: /ping
       volumes:
         - name: tiddlywiki-wiki
           persistentVolumeClaim:

--- a/k8s/kustomize/tiddlywiki/deployment.yaml
+++ b/k8s/kustomize/tiddlywiki/deployment.yaml
@@ -18,6 +18,8 @@ spec:
           env:
             - name: TIDDLYWIKI_AUTH_HEADER
               value: "X-Forwarded-Preferred-Username"
+            - name: TIDDLYWIKI_DEBUG
+              value: "debug"
           volumeMounts:
             - mountPath: /wiki
               name: tiddlywiki-wiki
@@ -33,12 +35,18 @@ spec:
             failureThreshold: 1
             httpGet:
               port: tiddlywiki-http
+              httpHeaders:
+                - name: "X-Forwarded-Preferred-Username"
+                  value: "k8s-readiness-probe"
               path: /
           livenessProbe:
             initialDelaySeconds: 10
             failureThreshold: 1
             httpGet:
               port: tiddlywiki-http
+              httpHeaders:
+                - name: "X-Forwarded-Preferred-Username"
+                  value: "k8s-liveness-probe"
               path: /
         # sidecar to provide oauth2 authentication to tiddlywiki
         - name: oauth2-proxy

--- a/k8s/kustomize/tiddlywiki/deployment.yaml
+++ b/k8s/kustomize/tiddlywiki/deployment.yaml
@@ -35,9 +35,6 @@ spec:
             failureThreshold: 1
             tcpSocket:
               port: tiddlywiki-http
-          envFrom:
-            - secretRef:
-                name: tiddlywiki-creds-secret
       volumes:
         - name: tiddlywiki-wiki
           persistentVolumeClaim:

--- a/k8s/kustomize/tiddlywiki/deployment.yaml
+++ b/k8s/kustomize/tiddlywiki/deployment.yaml
@@ -15,6 +15,9 @@ spec:
         - name: tiddlywiki
           image: tiddlywiki
           imagePullPolicy: Always
+          env:
+            - name: TIDDLYWIKI_AUTH_HEADER
+              value: "X-Forwarded-Preferred-Username"
           volumeMounts:
             - mountPath: /wiki
               name: tiddlywiki-wiki

--- a/k8s/kustomize/tiddlywiki/deployment.yaml
+++ b/k8s/kustomize/tiddlywiki/deployment.yaml
@@ -1,0 +1,45 @@
+#
+# admin
+# do k8s sg cluster definitions
+# tiddlywiki
+#
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tiddlywiki-server
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+        - name: tiddlywiki-server
+          image: tiddlywiki-node
+          imagePullPolicy: Always
+          volumeMounts:
+            - mountPath: /wiki
+              name: tiddlywiki-wiki
+              # subPath required as tiddlywiki-node image expects an empty dir
+              subPath: tiddlywiki
+          ports:
+            - name: tiddlywiki-http
+              containerPort: 8080
+          # tcp socket probe is used instead of http get as http get probes
+          # detects a false failure when basic http authentication is enabled.
+          readinessProbe:
+            initialDelaySeconds: 10
+            failureThreshold: 1
+            tcpSocket:
+              port: tiddlywiki-http
+          livenessProbe:
+            initialDelaySeconds: 10
+            failureThreshold: 1
+            tcpSocket:
+              port: tiddlywiki-http
+          envFrom:
+            - secretRef:
+                name: tiddlywiki-creds-secret
+      volumes:
+        - name: tiddlywiki-wiki
+          persistentVolumeClaim:
+            claimName: tiddlywiki-wiki-pvc

--- a/k8s/kustomize/tiddlywiki/deployment.yaml
+++ b/k8s/kustomize/tiddlywiki/deployment.yaml
@@ -74,7 +74,7 @@ spec:
             - "--redeem-url=https://keycloak.mrzzy.co/auth/realms/tiddlywiki/protocol/openid-connect/token"
             - "--profile-url=https://keycloak.mrzzy.co/auth/realms/tiddlywiki/protocol/openid-connect/userinfo"
             - "--validate-url=https://keycloak.mrzzy.co/auth/realms/tiddlywiki/protocol/openid-connect/userinfo"
-            - "--scope=email"
+            - "--scope='profile email'"
               # allow all emails from all domains to authenticate
             - "--email-domain=*"
               # disable default oauth-proxy logo

--- a/k8s/kustomize/tiddlywiki/deployment.yaml
+++ b/k8s/kustomize/tiddlywiki/deployment.yaml
@@ -68,13 +68,14 @@ spec:
             - "--reverse-proxy=true"
               # passes username as X-Forwarded-User header
             - "--pass-user-headers=true"
-              # keycloak oauth2 config
-            - "--provider=keycloak"
+              # keycloak oauth2 config via oauth2-proxy's oidc provider
+            - "--provider=oidc"
+            - "--oidc-issuer-url=https://keycloak.mrzzy.co/auth/realms/tiddlywiki"
             - "--login-url=https://keycloak.mrzzy.co/auth/realms/tiddlywiki/protocol/openid-connect/auth"
             - "--redeem-url=https://keycloak.mrzzy.co/auth/realms/tiddlywiki/protocol/openid-connect/token"
             - "--profile-url=https://keycloak.mrzzy.co/auth/realms/tiddlywiki/protocol/openid-connect/userinfo"
             - "--validate-url=https://keycloak.mrzzy.co/auth/realms/tiddlywiki/protocol/openid-connect/userinfo"
-            - "--scope='profile email'"
+            - "--scope=openid profile email"
               # allow all emails from all domains to authenticate
             - "--email-domain=*"
               # disable default oauth-proxy logo

--- a/k8s/kustomize/tiddlywiki/deployment.yaml
+++ b/k8s/kustomize/tiddlywiki/deployment.yaml
@@ -17,7 +17,8 @@ spec:
           imagePullPolicy: Always
           env:
             - name: TIDDLYWIKI_AUTH_HEADER
-              value: "X-Forwarded-Preferred-Username"
+              # tiddlywiki matches auth header in lowercase
+              value: "x-forwarded-preferred-username"
             - name: TIDDLYWIKI_DEBUG
               value: "debug"
           volumeMounts:
@@ -32,22 +33,20 @@ spec:
           # detects a false failure when basic http authentication is enabled.
           readinessProbe:
             initialDelaySeconds: 10
-            failureThreshold: 1
+            failureThreshold: 3
             httpGet:
               port: tiddlywiki-http
               httpHeaders:
-                - name: "X-Forwarded-Preferred-Username"
+                - name: X-Forwarded-Preferred-Username
                   value: "k8s-readiness-probe"
-              path: /
           livenessProbe:
             initialDelaySeconds: 10
-            failureThreshold: 1
+            failureThreshold: 3
             httpGet:
               port: tiddlywiki-http
               httpHeaders:
-                - name: "X-Forwarded-Preferred-Username"
+                - name: X-Forwarded-Preferred-Username
                   value: "k8s-liveness-probe"
-              path: /
         # sidecar to provide oauth2 authentication to tiddlywiki
         - name: oauth2-proxy
           image: oauth2-proxy
@@ -82,13 +81,13 @@ spec:
             - "--custom-sign-in-logo=-"
           readinessProbe:
             initialDelaySeconds: 10
-            failureThreshold: 1
+            failureThreshold: 3
             httpGet:
               port: oauth2-http
               path: /ping
           livenessProbe:
             initialDelaySeconds: 10
-            failureThreshold: 1
+            failureThreshold: 3
             httpGet:
               port: oauth2-http
               path: /ping

--- a/k8s/kustomize/tiddlywiki/deployment.yaml
+++ b/k8s/kustomize/tiddlywiki/deployment.yaml
@@ -67,6 +67,8 @@ spec:
             - "--scope=email"
               # allow all emails from all domains to authenticate
             - "--email-domain=*"
+              # disable default oauth-proxy logo
+            - "--custom-sign-in-logo=-"
           readinessProbe:
             initialDelaySeconds: 10
             failureThreshold: 1

--- a/k8s/kustomize/tiddlywiki/ingress.yaml
+++ b/k8s/kustomize/tiddlywiki/ingress.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: tiddlywiki
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    #cert-manager.io/cluster-issuer: "letsencrypt-production"
+spec:
+  tls:
+  - hosts:
+    - wiki.mrzzy.co
+    secretName: tiddlywiki-tls # pragma: allowlist secret
+  rules:
+  - host: wiki.mrzzy.co
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          serviceName: tiddlywiki
+          servicePort: 80

--- a/k8s/kustomize/tiddlywiki/ingress.yaml
+++ b/k8s/kustomize/tiddlywiki/ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: tiddlywiki
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    #cert-manager.io/cluster-issuer: "letsencrypt-production"
+    cert-manager.io/cluster-issuer: "letsencrypt-production"
 spec:
   tls:
   - hosts:

--- a/k8s/kustomize/tiddlywiki/ingress.yaml
+++ b/k8s/kustomize/tiddlywiki/ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: tiddlywiki
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    cert-manager.io/cluster-issuer: "letsencrypt-production"
+    cert-manager.io/cluster-issuer: "letsencrypt-staging"
 spec:
   tls:
   - hosts:

--- a/k8s/kustomize/tiddlywiki/ingress.yaml
+++ b/k8s/kustomize/tiddlywiki/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: tiddlywiki
@@ -17,5 +17,7 @@ spec:
       - path: /
         pathType: Prefix
         backend:
-          serviceName: tiddlywiki
-          servicePort: 80
+          service:
+            name: tiddlywiki
+            port:
+              name: http

--- a/k8s/kustomize/tiddlywiki/ingress.yaml
+++ b/k8s/kustomize/tiddlywiki/ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: tiddlywiki
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    cert-manager.io/cluster-issuer: "letsencrypt-staging"
+    cert-manager.io/cluster-issuer: "letsencrypt-production"
 spec:
   tls:
   - hosts:

--- a/k8s/kustomize/tiddlywiki/kustomization.yaml
+++ b/k8s/kustomize/tiddlywiki/kustomization.yaml
@@ -1,6 +1,5 @@
 #
-# admin
-# do k8s sg cluster definitions
+# nimbus
 # tiddlywiki
 #
 

--- a/k8s/kustomize/tiddlywiki/kustomization.yaml
+++ b/k8s/kustomize/tiddlywiki/kustomization.yaml
@@ -15,9 +15,9 @@ namespace: tiddlywiki
 commonLabels:
   app: tiddlywiki
 images:
-  - name: tiddlywiki-node
-    newName: ghcr.io/mrzzy/tiddlywiki-node
-    newTag: 5.1.23
+  - name: tiddlywiki
+    newName: ghcr.io/mrzzy/tiddlywiki
+    newTag: 5.1.22-0.0.1-alpha-1-gd2c5460
 secretGenerator:
   - name: tiddlywiki-creds-secret
     literals:

--- a/k8s/kustomize/tiddlywiki/kustomization.yaml
+++ b/k8s/kustomize/tiddlywiki/kustomization.yaml
@@ -18,8 +18,3 @@ images:
   - name: tiddlywiki
     newName: ghcr.io/mrzzy/tiddlywiki
     newTag: 5.1.22-0.0.1-alpha-1-gd2c5460
-secretGenerator:
-  - name: tiddlywiki-creds-secret
-    literals:
-      - TIDDLYWIKI_USERNAME=
-      - TIDDLYWIKI_PASSWORD=

--- a/k8s/kustomize/tiddlywiki/kustomization.yaml
+++ b/k8s/kustomize/tiddlywiki/kustomization.yaml
@@ -21,7 +21,7 @@ resources:
 images:
   - name: tiddlywiki
     newName: ghcr.io/mrzzy/tiddlywiki
-    newTag: 5.1.22-0.0.1-alpha-1-gd2c5460
+    newTag: 5.1.22-0.0.1-alpha-3-g4ad5630
   - name: oauth2-proxy
     newName: quay.io/oauth2-proxy/oauth2-proxy
     newTag: v7.1.3

--- a/k8s/kustomize/tiddlywiki/kustomization.yaml
+++ b/k8s/kustomize/tiddlywiki/kustomization.yaml
@@ -21,7 +21,7 @@ resources:
 images:
   - name: tiddlywiki
     newName: ghcr.io/mrzzy/tiddlywiki
-    newTag: 5.1.22-0.0.1-alpha-3-g4ad5630
+    newTag: 5.1.22-0.0.1-alpha-7-g3cf6de5
   - name: oauth2-proxy
     newName: quay.io/oauth2-proxy/oauth2-proxy
     newTag: v7.1.3

--- a/k8s/kustomize/tiddlywiki/kustomization.yaml
+++ b/k8s/kustomize/tiddlywiki/kustomization.yaml
@@ -4,6 +4,11 @@
 #
 
 apiVersion: kustomize.config.k8s.io/v1beta1
+namespace: tiddlywiki
+commonLabels:
+  app: tiddlywiki
+  version: 5.1.22
+  part-of: tiddlywiki
 kind: Kustomization
 resources:
 - deployment.yaml
@@ -11,10 +16,6 @@ resources:
 - namespace.yaml
 - service.yaml
 - ingress.yaml
-namespace: tiddlywiki
-commonLabels:
-  app: tiddlywiki
-  version: 5.1.22
 images:
   - name: tiddlywiki
     newName: ghcr.io/mrzzy/tiddlywiki

--- a/k8s/kustomize/tiddlywiki/kustomization.yaml
+++ b/k8s/kustomize/tiddlywiki/kustomization.yaml
@@ -1,0 +1,26 @@
+#
+# admin
+# do k8s sg cluster definitions
+# tiddlywiki
+#
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- deployment.yaml
+- pvc.yaml
+- namespace.yaml
+- service.yaml
+- ingress.yaml
+namespace: tiddlywiki
+commonLabels:
+  app: tiddlywiki
+images:
+  - name: tiddlywiki-node
+    newName: ghcr.io/mrzzy/tiddlywiki-node
+    newTag: 5.1.23
+secretGenerator:
+  - name: tiddlywiki-creds-secret
+    literals:
+      - TIDDLYWIKI_USERNAME=
+      - TIDDLYWIKI_PASSWORD=

--- a/k8s/kustomize/tiddlywiki/kustomization.yaml
+++ b/k8s/kustomize/tiddlywiki/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
 namespace: tiddlywiki
 commonLabels:
   app: tiddlywiki
+  version: 5.1.22
 images:
   - name: tiddlywiki
     newName: ghcr.io/mrzzy/tiddlywiki

--- a/k8s/kustomize/tiddlywiki/kustomization.yaml
+++ b/k8s/kustomize/tiddlywiki/kustomization.yaml
@@ -10,6 +10,8 @@ commonLabels:
   app: tiddlywiki
   version: 5.1.22
   part-of: tiddlywiki
+  deployed-by: argocd
+  managed-by: nimbus-ci
 resources:
 - deployment.yaml
 - pvc.yaml

--- a/k8s/kustomize/tiddlywiki/kustomization.yaml
+++ b/k8s/kustomize/tiddlywiki/kustomization.yaml
@@ -4,12 +4,12 @@
 #
 
 apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 namespace: tiddlywiki
 commonLabels:
   app: tiddlywiki
   version: 5.1.22
   part-of: tiddlywiki
-kind: Kustomization
 resources:
 - deployment.yaml
 - pvc.yaml
@@ -20,3 +20,6 @@ images:
   - name: tiddlywiki
     newName: ghcr.io/mrzzy/tiddlywiki
     newTag: 5.1.22-0.0.1-alpha-1-gd2c5460
+  - name: oauth2-proxy
+    newName: quay.io/oauth2-proxy/oauth2-proxy
+    newTag: v7.1.3

--- a/k8s/kustomize/tiddlywiki/namespace.yaml
+++ b/k8s/kustomize/tiddlywiki/namespace.yaml
@@ -1,0 +1,8 @@
+#
+# admin
+# do k8s sg cluster definitions
+#
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tiddlywiki

--- a/k8s/kustomize/tiddlywiki/namespace.yaml
+++ b/k8s/kustomize/tiddlywiki/namespace.yaml
@@ -1,5 +1,5 @@
 #
-# admin
+# nimbus
 # do k8s sg cluster definitions
 #
 apiVersion: v1

--- a/k8s/kustomize/tiddlywiki/pvc.yaml
+++ b/k8s/kustomize/tiddlywiki/pvc.yaml
@@ -1,6 +1,5 @@
 #
-# admin
-# do k8s sg cluster definitions
+# nimbus
 # tiddlywiki
 #
 

--- a/k8s/kustomize/tiddlywiki/pvc.yaml
+++ b/k8s/kustomize/tiddlywiki/pvc.yaml
@@ -6,7 +6,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: tiddlywiki-wiki-pvc
+  name: tiddlywiki
 spec:
   accessModes:
     - ReadWriteOnce

--- a/k8s/kustomize/tiddlywiki/pvc.yaml
+++ b/k8s/kustomize/tiddlywiki/pvc.yaml
@@ -12,4 +12,4 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 6Gi
+      storage: 10Gi

--- a/k8s/kustomize/tiddlywiki/pvc.yaml
+++ b/k8s/kustomize/tiddlywiki/pvc.yaml
@@ -9,7 +9,7 @@ metadata:
   name: tiddlywiki
 spec:
   accessModes:
-    - ReadWriteMany
+    - ReadWriteOnce
   resources:
     requests:
       storage: 6Gi

--- a/k8s/kustomize/tiddlywiki/pvc.yaml
+++ b/k8s/kustomize/tiddlywiki/pvc.yaml
@@ -9,7 +9,7 @@ metadata:
   name: tiddlywiki
 spec:
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteMany
   resources:
     requests:
       storage: 6Gi

--- a/k8s/kustomize/tiddlywiki/pvc.yaml
+++ b/k8s/kustomize/tiddlywiki/pvc.yaml
@@ -1,0 +1,16 @@
+#
+# admin
+# do k8s sg cluster definitions
+# tiddlywiki
+#
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: tiddlywiki-wiki-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 6Gi

--- a/k8s/kustomize/tiddlywiki/service.yaml
+++ b/k8s/kustomize/tiddlywiki/service.yaml
@@ -1,6 +1,5 @@
 #
-# admin
-# do k8s sg cluster definitions
+# nimbus
 # tiddlywiki
 #
 

--- a/k8s/kustomize/tiddlywiki/service.yaml
+++ b/k8s/kustomize/tiddlywiki/service.yaml
@@ -1,0 +1,17 @@
+#
+# admin
+# do k8s sg cluster definitions
+# tiddlywiki
+#
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: tiddlywiki
+spec:
+  type: ClusterIP
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8080
+    protocol: TCP

--- a/k8s/kustomize/tiddlywiki/service.yaml
+++ b/k8s/kustomize/tiddlywiki/service.yaml
@@ -12,5 +12,5 @@ spec:
   ports:
   - name: http
     port: 80
-    targetPort: 8080
+    targetPort: oauth2-http
     protocol: TCP


### PR DESCRIPTION
Deploy Tiddlywiki on Linode K8s:
- implements part of #20 
- uses [mrzzy/tiddlywiki-docker](https://github.com/mrzzy/tiddlywiki-docker) image to deploy tiddlywiki.
- adds kustomization & K8s manifests to deploy Tiddlywiki on Linode K8s.
- adds ArgoCD app to register Tiddlywiki deployment with ArgoCD.
- includes ingress to direct traffic from `wiki.mrzzy.co` to `tiddlywiki` service.
- deploys [oauth2-proxy](https://oauth2-proxy.github.io) to provide OAuth2 authentication with Keycloak as authentication server.
