### PR TITLE
Deploy Operator Lifecycle Manager on Linode K8s

### DIFF
--- a/k8s/argocd/apps/operator-lifecycle-manager.yaml
+++ b/k8s/argocd/apps/operator-lifecycle-manager.yaml
@@ -1,0 +1,19 @@
+#
+# nimbus
+# argocd app to deploy operator-lifecycle-manager
+#
+
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: operator-lifecycle-manager
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/mrzzy/nimbus.git
+    targetRevision: HEAD
+    path: k8s/kustomize/operator-lifecycle-manager
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: olm

--- a/k8s/kustomize/operator-lifecycle-manager/kustomization.yaml
+++ b/k8s/kustomize/operator-lifecycle-manager/kustomization.yaml
@@ -1,0 +1,11 @@
+#
+# nimbus
+# operator-lifecycle-manager kustomization
+#
+
+# deploys operator lifecycle manager
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://raw.githubusercontent.com/operator-framework/operator-lifecycle-manager/v0.18.3/deploy/upstream/quickstart/crds.yaml
+  - https://raw.githubusercontent.com/operator-framework/operator-lifecycle-manager/v0.18.3/deploy/upstream/quickstart/olm.yaml


### PR DESCRIPTION
### Motivation
Deploy OLM as a prerequisite for deploying Keycloak operator. 

### This PR
Deploy Operator Lifecycle Manager (OLM) on Linode K8s:
- Add kustomization to deploy OLM on cluster.
- Add ArgoCD app to register deployment with ArgoCD.