### PR TITLE
Deploy Keycloak on LInode LKE

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -31,7 +31,7 @@
       "name": "JwtTokenDetector"
     },
     {
-      "keyword_exclude": null,
+      "keyword_exclude": "secretName",
       "name": "KeywordDetector"
     },
     {

--- a/k8s/argocd/apps/keycloak.yaml
+++ b/k8s/argocd/apps/keycloak.yaml
@@ -1,0 +1,19 @@
+#
+# nimbus
+# argocd app to deploy keycloak
+#
+
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: keycloak
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/mrzzy/nimbus.git
+    targetRevision: HEAD
+    path: k8s/kustomize/keycloak
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: keycloak

--- a/k8s/kustomize/keycloak/ingress.yaml
+++ b/k8s/kustomize/keycloak/ingress.yaml
@@ -8,6 +8,7 @@ metadata:
                             location ~* "^/auth/realms/master/metrics" {
                                 return 301 /auth/realms/master;
                               }
+    cert-manager.io/cluster-issuer: "letsencrypt-production"
   labels:
     app: keycloak
   name: keycloak
@@ -23,3 +24,8 @@ spec:
               number: 8443
         path: /
         pathType: ImplementationSpecific
+
+  tls:
+  - hosts:
+    - keycloak.mrzzy.co
+    secretName: keycloak-cert

--- a/k8s/kustomize/keycloak/ingress.yaml
+++ b/k8s/kustomize/keycloak/ingress.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/backend-protocol: HTTPS
+    nginx.ingress.kubernetes.io/server-snippet: |2-
+
+                            location ~* "^/auth/realms/master/metrics" {
+                                return 301 /auth/realms/master;
+                              }
+  labels:
+    app: keycloak
+  name: keycloak
+spec:
+  rules:
+  - host: keycloak.mrzzy.co
+    http:
+      paths:
+      - backend:
+          service:
+            name: keycloak
+            port:
+              number: 8443
+        path: /
+        pathType: ImplementationSpecific

--- a/k8s/kustomize/keycloak/keycloak.yaml
+++ b/k8s/kustomize/keycloak/keycloak.yaml
@@ -1,0 +1,15 @@
+#
+# nimbus
+# keycloak CRD
+#
+
+apiVersion: keycloak.org/v1alpha1
+kind: Keycloak
+metadata:
+  name: keycloak
+  labels:
+   app: keycloak
+spec:
+  instances: 1
+  externalAccess:
+    enabled: false

--- a/k8s/kustomize/keycloak/kustomization.yaml
+++ b/k8s/kustomize/keycloak/kustomization.yaml
@@ -1,0 +1,7 @@
+#
+# nimbus
+# kustomization to deploy keycloak
+#
+
+resources:
+- github.com/keycloak/keycloak-operator/deploy?ref=15.0.0

--- a/k8s/kustomize/keycloak/kustomization.yaml
+++ b/k8s/kustomize/keycloak/kustomization.yaml
@@ -3,5 +3,7 @@
 # kustomization to deploy keycloak
 #
 
+namespace: keycloak
 resources:
 - github.com/keycloak/keycloak-operator/deploy?ref=15.0.0
+- keycloak

--- a/k8s/kustomize/keycloak/kustomization.yaml
+++ b/k8s/kustomize/keycloak/kustomization.yaml
@@ -6,4 +6,5 @@
 namespace: keycloak
 resources:
 - github.com/keycloak/keycloak-operator/deploy?ref=15.0.0
-- keycloak
+- keycloak.yaml
+- ingress.yaml


### PR DESCRIPTION
## Motivation
Deploy Keycloak as OAuth authentication provider required by #20 

## This PR
Deploys Keycloak on LInode LKE:
- deploys Keycloak operator using [kustomize base on keycloak-operator repo](https://github.com/keycloak/keycloak-operator/tree/master/deploy).
- deploys Keycloak standalone with `Keycloak` CRD.
- exposes Keycloak on `keycloak.mrzzy.co` with `Ingress` secured by LetsEncrypt TLS.