### PR TITLE
Deploy Argo Workflows on Linode LKE

### DIFF
--- a/k8s/argocd/apps/argo-workflows.yaml
+++ b/k8s/argocd/apps/argo-workflows.yaml
@@ -1,0 +1,19 @@
+#
+# nimbus
+# argocd app to deploy argo-workflows
+#
+
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argo-workflows
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/mrzzy/nimbus.git
+    targetRevision: HEAD
+    path: k8s/kustomize/argo-workflows
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argo

--- a/k8s/kustomize/argo-workflows/kustomization.yml
+++ b/k8s/kustomize/argo-workflows/kustomization.yml
@@ -1,0 +1,14 @@
+
+# nimbus
+# argo-workflows kustomization
+#
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: argo
+commonLabels:
+  managed-by: nimbus
+  deployed-by: argocd
+resources:
+- https://raw.githubusercontent.com/argoproj/argo-workflows/v3.1.6/manifests/install.yaml
+- namespace.yaml

--- a/k8s/kustomize/argo-workflows/namespace.yaml
+++ b/k8s/kustomize/argo-workflows/namespace.yaml
@@ -1,0 +1,9 @@
+#
+# nimbus
+# argo-workflows namespace
+#
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: argo


### PR DESCRIPTION
## Motivation
Deploy Argo Workflows required by #20

## This PR
Deploy Argo Workflows to `argo` namespace:
- add kustomization to deploy argo workflows
- add ArgoCD app to register argo workflows kustomize deploy with ArgoCD
