### PR TITLE
Add backup pipeline for Tiddlywiki deploy on Linode LKE

### DIFF
--- a/k8s/kustomize/argo-workflows/kustomization.yaml
+++ b/k8s/kustomize/argo-workflows/kustomization.yaml
@@ -14,3 +14,4 @@ resources:
 - namespace.yaml
 - role.yaml
 - rolebinding.yaml
+- tiddlywiki-archive

--- a/k8s/kustomize/argo-workflows/kustomization.yaml
+++ b/k8s/kustomize/argo-workflows/kustomization.yaml
@@ -1,4 +1,4 @@
-
+#
 # nimbus
 # argo-workflows kustomization
 #
@@ -12,3 +12,5 @@ commonLabels:
 resources:
 - https://raw.githubusercontent.com/argoproj/argo-workflows/v3.1.6/manifests/install.yaml
 - namespace.yaml
+- role.yaml
+- rolebinding.yaml

--- a/k8s/kustomize/argo-workflows/role.yaml
+++ b/k8s/kustomize/argo-workflows/role.yaml
@@ -1,0 +1,30 @@
+#
+# nimbus
+# Argo Workflows
+# RBAC Role that provides required permissions for executing workflows
+#
+
+# sourced from: https://argoproj.github.io/argo-workflows/workflow-rbac/
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: workflow
+rules:
+# pod get/watch is used to identify the container IDs of the current pod
+# pod patch is used to annotate the step's outputs back to controller (e.g. artifact location)
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - watch
+  - patch
+# logs get/watch are used to get the pods logs for script outputs, and for log archival
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
+  - watch

--- a/k8s/kustomize/argo-workflows/rolebinding.yaml
+++ b/k8s/kustomize/argo-workflows/rolebinding.yaml
@@ -1,0 +1,17 @@
+#
+# nimbus
+# Argo Workflows
+# RBAC Role Bindinng
+#
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: default-workflow
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: workflow
+subjects:
+- kind: ServiceAccount
+  name: default

--- a/k8s/kustomize/argo-workflows/tiddlywiki-archive/kustomization.yaml
+++ b/k8s/kustomize/argo-workflows/tiddlywiki-archive/kustomization.yaml
@@ -1,0 +1,21 @@
+#
+# nimbus
+# tiddlywiki archive workflow
+# kustomization
+#
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: argo
+commonLabels:
+  part-of: tiddlywiki-archive
+  deployed-by: argocd
+  managed-by: nimbus-ci
+resources:
+- workflow.yaml
+configMapGenerator:
+- name: tiddlywiki-archive
+  options:
+    disableNameSuffixHash: true
+  files:
+  - rclone.conf

--- a/k8s/kustomize/argo-workflows/tiddlywiki-archive/rclone.conf
+++ b/k8s/kustomize/argo-workflows/tiddlywiki-archive/rclone.conf
@@ -1,0 +1,10 @@
+[sftp]
+type = sftp
+host = tiddlywiki.tiddlywiki.svc
+user = sftp
+key_file = /ssh_private_key
+
+[wasabi]
+type = s3
+provider = Wasabi
+env_auth = true

--- a/k8s/kustomize/argo-workflows/tiddlywiki-archive/workflow.yaml
+++ b/k8s/kustomize/argo-workflows/tiddlywiki-archive/workflow.yaml
@@ -4,67 +4,71 @@
 #
 
 apiVersion: argoproj.io/v1alpha1
-kind: WorkflowTemplate
+kind: CronWorkflow
 metadata:
   name: archive-tiddlywiki
 spec:
-  entrypoint: rclone-tiddlers
-  arguments:
-    parameters:
-      # wasabi region where the target bucket is located
-      - name: wasabi-region
-        value: eu-central-1
-      # the target bucket to write archived tiddlers to.
-      - name: wasabi-bucket
-        value: mrzzy-co-tiddlywiki-archive
-  templates:
-    - name: rclone-tiddlers
-      script:
-        image: rclone/rclone:1.56.0
-        command: [ash]
-        source: |
-          set -ex
-          # rclone makes a copy of the rclone file to store mutable state:
-          # https://github.com/rclone/rclone/issues/3655
-          # this breaks as rclone.conf is mounted on read only basis.
-          # hence the mount and copy to workaround the rclone mutablity requirement.
-          mkdir -p /config/rclone
-          cp /rclone.conf /config/rclone/rclone.conf
+  # schedule workflow to run at 3am.
+  schedule: "0 3 * * *"
+  timezone: Asia/Singapore
+  concurrencyPolicy: Allow
+  workflowSpec:
+    entrypoint: rclone-tiddlers
+    arguments:
+      parameters:
+        # wasabi region where the target bucket is located
+        - name: wasabi-region
+          value: eu-central-1
+        # the target bucket to write archived tiddlers to.
+        - name: wasabi-bucket
+          value: mrzzy-co-tiddlywiki-archive
+    templates:
+      - name: rclone-tiddlers
+        script:
+          image: rclone/rclone:1.56.0
+          command: [ash]
+          source: |
+            set -ex
+            # rclone makes a copy of the rclone file to store mutable state:
+            # https://github.com/rclone/rclone/issues/3655
+            # this breaks as rclone.conf is mounted on read only basis.
+            # hence the mount and copy to workaround the rclone mutablity requirement.
+            mkdir -p /config/rclone
+            cp /rclone.conf /config/rclone/rclone.conf
 
-          # use rclone to copy tiddlywiki tiddlers to wasabi S3
-          rclone copy \
-            sftp:wiki \
-            wasabi:{{ workflow.parameters.wasabi-bucket }}/wiki-$(date -u  +"%Y_%m_%d__%H_%M_%S") \
-            -vv --retries 1 --low-level-retries 1 --dump bodies
-        env:
-          - name: RCLONE_CONFIG_WASABI_ACCESS_KEY_ID
-            valueFrom:
-              secretKeyRef:
-                name: tiddlywiki-archive
-                key: RCLONE_CONFIG_WASABI_ACCESS_KEY_ID
-          - name: RCLONE_CONFIG_WASABI_SECRET_ACCESS_KEY
-            valueFrom:
-              secretKeyRef:
-                name: tiddlywiki-archive
-                key: RCLONE_CONFIG_WASABI_SECRET_ACCESS_KEY
-          - name: RCLONE_CONFIG_WASABI_ENDPOINT
-            value: "s3.{{ workflow.parameters.wasabi-region }}.wasabisys.com"
-          - name: RCLONE_CONFIG_WASABI_REGION
-            value: "{{ workflow.parameters.wasabi-region }}"
-        volumeMounts:
-          - mountPath: /ssh_private_key
-            name: ssh-key
-            subPath: ssh_private_key
-          - mountPath: /rclone.conf
-            name: rclone-conf
-            subPath: rclone.conf
-
-  volumes:
-    - name: ssh-key
-      secret:
-        secretName: tiddlywiki-archive
-    - name: rclone-conf
-      configMap:
-        name: tiddlywiki-archive
-  podGC:
-    strategy: OnWorkflowSuccess
+            # use rclone to copy tiddlywiki tiddlers to wasabi S3
+            rclone copy \
+              sftp:wiki \
+              wasabi:{{ workflow.parameters.wasabi-bucket }}/wiki-$(date -u  +"%Y_%m_%d__%H_%M_%S") \
+              -vv --retries 1 --low-level-retries 1 --dump bodies
+          env:
+            - name: RCLONE_CONFIG_WASABI_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: tiddlywiki-archive
+                  key: RCLONE_CONFIG_WASABI_ACCESS_KEY_ID
+            - name: RCLONE_CONFIG_WASABI_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: tiddlywiki-archive
+                  key: RCLONE_CONFIG_WASABI_SECRET_ACCESS_KEY
+            - name: RCLONE_CONFIG_WASABI_ENDPOINT
+              value: "s3.{{ workflow.parameters.wasabi-region }}.wasabisys.com"
+            - name: RCLONE_CONFIG_WASABI_REGION
+              value: "{{ workflow.parameters.wasabi-region }}"
+          volumeMounts:
+            - mountPath: /ssh_private_key
+              name: ssh-key
+              subPath: ssh_private_key
+            - mountPath: /rclone.conf
+              name: rclone-conf
+              subPath: rclone.conf
+    volumes:
+      - name: ssh-key
+        secret:
+          secretName: tiddlywiki-archive
+      - name: rclone-conf
+        configMap:
+          name: tiddlywiki-archive
+    podGC:
+      strategy: OnWorkflowSuccess

--- a/k8s/kustomize/argo-workflows/tiddlywiki-archive/workflow.yaml
+++ b/k8s/kustomize/argo-workflows/tiddlywiki-archive/workflow.yaml
@@ -32,7 +32,7 @@ spec:
             # rclone makes a copy of the rclone file to store mutable state:
             # https://github.com/rclone/rclone/issues/3655
             # this breaks as rclone.conf is mounted on read only basis.
-            # hence the mount and copy to workaround the rclone mutablity requirement.
+            # hence the mount and copy to workaround the rclone mutability requirement.
             mkdir -p /config/rclone
             cp /rclone.conf /config/rclone/rclone.conf
 

--- a/k8s/kustomize/argo-workflows/tiddlywiki-archive/workflow.yaml
+++ b/k8s/kustomize/argo-workflows/tiddlywiki-archive/workflow.yaml
@@ -1,0 +1,70 @@
+#
+# nimbus
+# tiddlywiki archive workflow
+#
+
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: archive-tiddlywiki
+spec:
+  entrypoint: rclone-tiddlers
+  arguments:
+    parameters:
+      # wasabi region where the target bucket is located
+      - name: wasabi-region
+        value: eu-central-1
+      # the target bucket to write archived tiddlers to.
+      - name: wasabi-bucket
+        value: mrzzy-co-tiddlywiki-archive
+  templates:
+    - name: rclone-tiddlers
+      script:
+        image: rclone/rclone:1.56.0
+        command: [ash]
+        source: |
+          set -ex
+          # rclone makes a copy of the rclone file to store mutable state:
+          # https://github.com/rclone/rclone/issues/3655
+          # this breaks as rclone.conf is mounted on read only basis.
+          # hence the mount and copy to workaround the rclone mutablity requirement.
+          mkdir -p /config/rclone
+          cp /rclone.conf /config/rclone/rclone.conf
+
+          # use rclone to copy tiddlywiki tiddlers to wasabi S3
+          rclone copy \
+            sftp:wiki \
+            wasabi:{{ workflow.parameters.wasabi-bucket }}/wiki-$(date -u  +"%Y_%m_%d__%H_%M_%S") \
+            -vv --retries 1 --low-level-retries 1 --dump bodies
+        env:
+          - name: RCLONE_CONFIG_WASABI_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: tiddlywiki-archive
+                key: RCLONE_CONFIG_WASABI_ACCESS_KEY_ID
+          - name: RCLONE_CONFIG_WASABI_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: tiddlywiki-archive
+                key: RCLONE_CONFIG_WASABI_SECRET_ACCESS_KEY
+          - name: RCLONE_CONFIG_WASABI_ENDPOINT
+            value: "s3.{{ workflow.parameters.wasabi-region }}.wasabisys.com"
+          - name: RCLONE_CONFIG_WASABI_REGION
+            value: "{{ workflow.parameters.wasabi-region }}"
+        volumeMounts:
+          - mountPath: /ssh_private_key
+            name: ssh-key
+            subPath: ssh_private_key
+          - mountPath: /rclone.conf
+            name: rclone-conf
+            subPath: rclone.conf
+
+  volumes:
+    - name: ssh-key
+      secret:
+        secretName: tiddlywiki-archive
+    - name: rclone-conf
+      configMap:
+        name: tiddlywiki-archive
+  podGC:
+    strategy: OnWorkflowSuccess

--- a/k8s/kustomize/tiddlywiki/deployment.yaml
+++ b/k8s/kustomize/tiddlywiki/deployment.yaml
@@ -112,6 +112,9 @@ spec:
             - mountPath: /home/sftp/.ssh/authorized_keys
               name: tiddlywiki-ssh-key
               subPath: ssh_public_key.pub
+            - mountPath: /home/sftp/wiki
+              name: tiddlywiki-wiki
+              subPath: tiddlywiki
           readinessProbe:
             initialDelaySeconds: 10
             failureThreshold: 3

--- a/k8s/kustomize/tiddlywiki/deployment.yaml
+++ b/k8s/kustomize/tiddlywiki/deployment.yaml
@@ -112,7 +112,16 @@ spec:
             - mountPath: /home/sftp/.ssh/authorized_keys
               name: tiddlywiki-ssh-key
               subPath: ssh_public_key.pub
-        # TODO(mrzzy): add readiness and liveness probes.
+          readinessProbe:
+            initialDelaySeconds: 10
+            failureThreshold: 3
+            tcpSocket:
+              port: sftp
+          livenessProbe:
+            initialDelaySeconds: 10
+            failureThreshold: 3
+            tcpSocket:
+              port: sftp
 
       volumes:
         - name: tiddlywiki-wiki

--- a/k8s/kustomize/tiddlywiki/deployment.yaml
+++ b/k8s/kustomize/tiddlywiki/deployment.yaml
@@ -47,6 +47,7 @@ spec:
               httpHeaders:
                 - name: X-Forwarded-Preferred-Username
                   value: "k8s-liveness-probe"
+
         # sidecar to provide oauth2 authentication to tiddlywiki
         - name: oauth2-proxy
           image: oauth2-proxy
@@ -92,7 +93,31 @@ spec:
             httpGet:
               port: oauth2-http
               path: /ping
+
+        # sidecar to expose saved tiddler files to backup pipeline via SFTP
+        - name: sftp-export
+          image: sftp
+          env:
+            - name: SFTP_USERS
+              valueFrom:
+                secretKeyRef:
+                  key: SFTP_USERS
+                  name: tiddlywiki-sftp
+          ports:
+            - name: sftp
+              containerPort: 22
+          # mount the ssh keys used for authentication
+          # assumes 'sftp' user is used
+          volumeMounts:
+            - mountPath: /home/sftp/.ssh/authorized_keys
+              name: tiddlywiki-ssh-key
+              subPath: ssh_public_key.pub
+        # TODO(mrzzy): add readiness and liveness probes.
+
       volumes:
         - name: tiddlywiki-wiki
           persistentVolumeClaim:
             claimName: tiddlywiki
+        - name: tiddlywiki-ssh-key
+          secret:
+              secretName: tiddlywiki-sftp

--- a/k8s/kustomize/tiddlywiki/kustomization.yaml
+++ b/k8s/kustomize/tiddlywiki/kustomization.yaml
@@ -25,3 +25,6 @@ images:
   - name: oauth2-proxy
     newName: quay.io/oauth2-proxy/oauth2-proxy
     newTag: v7.1.3
+  - name: sftp
+    newName: atmoz/sftp
+    newTag: alpine

--- a/k8s/kustomize/tiddlywiki/kustomization.yaml
+++ b/k8s/kustomize/tiddlywiki/kustomization.yaml
@@ -19,12 +19,12 @@ resources:
 - service.yaml
 - ingress.yaml
 images:
-  - name: tiddlywiki
-    newName: ghcr.io/mrzzy/tiddlywiki
-    newTag: 5.1.22-0.0.1-alpha-7-g3cf6de5
-  - name: oauth2-proxy
-    newName: quay.io/oauth2-proxy/oauth2-proxy
-    newTag: v7.1.3
-  - name: sftp
-    newName: atmoz/sftp
-    newTag: alpine
+- name: tiddlywiki
+  newName: ghcr.io/mrzzy/tiddlywiki
+  newTag: 5.1.22-0.0.1-alpha-7-g3cf6de5
+- name: oauth2-proxy
+  newName: quay.io/oauth2-proxy/oauth2-proxy
+  newTag: v7.1.3
+- name: sftp
+  newName: atmoz/sftp
+  newTag: alpine

--- a/k8s/kustomize/tiddlywiki/service.yaml
+++ b/k8s/kustomize/tiddlywiki/service.yaml
@@ -14,3 +14,7 @@ spec:
     port: 80
     targetPort: oauth2-http
     protocol: TCP
+  - name: sftp
+    port: 22
+    targetPort: sftp
+    protocol: TCP


### PR DESCRIPTION
## Motivation
Fixes #20

Backup pipeline provides snapshot of tiddlers in Tiddlywiki which is useful for disaster recovery

## This PR
Adds backup pipeline (Argo CronWorkflow) to automatically snapshot Tiddlywiki in Wasabi Cloud Storage at 3am everyday:
- deploy sftp sidecar on tiddlywiki deployment to expose tiddlers via sftp
- add readiness & liveness probes for tiddlywiki's sftp sidecar
- export sftp port on tiddlywiki service
- mount tiddlywiki wiki volume in sftp container to expose saved tiddlers via sftp
- fix argo workflows unable to run properly due to missing rbac permissions
- add archive-tiddlywiki argo workflow to backup tiddlywiki to wasabi s3
- convert archive workflow to cron workflow running everyday at 3am
