### PR TITLE
feat(box): Autoformat & Automount Warp Disk on Warp VM startup

### DIFF
--- a/terraform/gcp/main.tf
+++ b/terraform/gcp/main.tf
@@ -99,7 +99,9 @@ resource "google_compute_instance" "wrap_vm" {
     }
   }
 
-  metadata_startup_script = templatefile("templates/warp_cloud_init.yaml", {
-    "warp_disk_device" : local.warp_disk_device
-  })
+  metadata = {
+    user-data = templatefile("templates/warp_cloud_init.yaml", {
+      "warp_disk_device" : local.warp_disk_device
+    })
+  }
 }

--- a/terraform/gcp/main.tf
+++ b/terraform/gcp/main.tf
@@ -4,7 +4,8 @@
 #
 
 locals {
-  allow_ssh_tag = "allow-ssh"
+  allow_ssh_tag    = "allow-ssh"
+  warp_disk_device = "/dev/disk/by-id/warp_disk"
 }
 
 terraform {
@@ -87,6 +88,8 @@ resource "google_compute_instance" "wrap_vm" {
 
   attached_disk {
     source = google_compute_disk.warp_disk.self_link
+    // accessible via /dev/disk/by-id
+    device_name = basename(local.warp_disk_device)
   }
 
   network_interface {
@@ -95,4 +98,8 @@ resource "google_compute_instance" "wrap_vm" {
       network_tier = "STANDARD"
     }
   }
+
+  metadata_startup_script = templatefile("templates/warp_cloud_init.yaml", {
+    "warp_disk_device" : local.warp_disk_device
+  })
 }

--- a/terraform/gcp/main.tf
+++ b/terraform/gcp/main.tf
@@ -4,8 +4,8 @@
 #
 
 locals {
-  allow_ssh_tag    = "allow-ssh"
-  warp_disk_device = "/dev/disk/by-id/warp_disk"
+  allow_ssh_tag = "allow-ssh"
+  warp_disk_id  = "warp-disk"
 }
 
 terraform {
@@ -88,8 +88,8 @@ resource "google_compute_instance" "wrap_vm" {
 
   attached_disk {
     source = google_compute_disk.warp_disk.self_link
-    // accessible via /dev/disk/by-id
-    device_name = basename(local.warp_disk_device)
+    // accessible via /dev/disk/by-id/google- prefix
+    device_name = local.warp_disk_id
   }
 
   network_interface {
@@ -101,7 +101,7 @@ resource "google_compute_instance" "wrap_vm" {
 
   metadata = {
     user-data = templatefile("templates/warp_cloud_init.yaml", {
-      "warp_disk_device" : local.warp_disk_device
+      "warp_disk_device" : "/dev/disk/by-id/google-${local.warp_disk_id}"
     })
   }
 }

--- a/terraform/gcp/templates/warp_cloud_init.yaml
+++ b/terraform/gcp/templates/warp_cloud_init.yaml
@@ -1,4 +1,4 @@
-#cloud-init
+#cloud-config
 bootcmd:
   # format warp disk with btrfs
   # verify that no fs exists on device before formatting

--- a/terraform/gcp/templates/warp_cloud_init.yaml
+++ b/terraform/gcp/templates/warp_cloud_init.yaml
@@ -8,7 +8,7 @@ bootcmd:
   # create mountpoint
   - mkdir -p /home/mrzzy/disk
 
-mount:
+mounts:
   # fstab entry to mount warp disk with the mrzzy user as owner
   - ["${warp_disk_device}", "/home/mrzzy/disk", "btrfs", "defaults,uid=mrzzy,gid=mrzzy", "0", "2"]
 

--- a/terraform/gcp/templates/warp_cloud_init.yaml
+++ b/terraform/gcp/templates/warp_cloud_init.yaml
@@ -1,0 +1,17 @@
+#cloud-init
+bootcmd:
+  # format warp disk with btrfs
+  # verify that no fs exists on device before formatting
+  - >-
+    test -z "$(blkid ${warp_disk_dev})" &&
+      mkfs.btrfs -L warp_disk ${ warp_disk_dev }
+  # create mountpoint
+  - mkdir -p /home/mrzzy/disk
+
+mount:
+  # fstab entry to mount warp disk with the mrzzy user as owner
+  - ["${warp_disk_dev}", "/home/mrzzy/disk", "btrfs", "defaults,uid=mrzzy,gid=mrzzy", "0", "2"]
+
+runcmd:
+  # mount warp disk as configured in fstab
+  - mount ${warp_disk_dev}

--- a/terraform/gcp/templates/warp_cloud_init.yaml
+++ b/terraform/gcp/templates/warp_cloud_init.yaml
@@ -5,12 +5,13 @@ bootcmd:
   - >-
     test -z "$(blkid ${warp_disk_device})" &&
       mkfs.btrfs -L warp_disk ${ warp_disk_device }
-  # create mountpoint
+  # create mountpoint with the mrzzy user as owner
   - mkdir -p /home/mrzzy/disk
+  - chown mrzzy:mrzzy /home/mrzzy/disk
 
 mounts:
-  # fstab entry to mount warp disk with the mrzzy user as owner
-  - ["${warp_disk_device}", "/home/mrzzy/disk", "btrfs", "defaults,uid=mrzzy,gid=mrzzy", "0", "2"]
+  # fstab entry to mount warp disk
+  - ["${warp_disk_device}", "/home/mrzzy/disk", "btrfs", "defaults", "0", "2"]
 
 runcmd:
   # mount warp disk as configured in fstab

--- a/terraform/gcp/templates/warp_cloud_init.yaml
+++ b/terraform/gcp/templates/warp_cloud_init.yaml
@@ -3,15 +3,15 @@ bootcmd:
   # format warp disk with btrfs
   # verify that no fs exists on device before formatting
   - >-
-    test -z "$(blkid ${warp_disk_dev})" &&
-      mkfs.btrfs -L warp_disk ${ warp_disk_dev }
+    test -z "$(blkid ${warp_disk_device})" &&
+      mkfs.btrfs -L warp_disk ${ warp_disk_device }
   # create mountpoint
   - mkdir -p /home/mrzzy/disk
 
 mount:
   # fstab entry to mount warp disk with the mrzzy user as owner
-  - ["${warp_disk_dev}", "/home/mrzzy/disk", "btrfs", "defaults,uid=mrzzy,gid=mrzzy", "0", "2"]
+  - ["${warp_disk_device}", "/home/mrzzy/disk", "btrfs", "defaults,uid=mrzzy,gid=mrzzy", "0", "2"]
 
 runcmd:
   # mount warp disk as configured in fstab
-  - mount ${warp_disk_dev}
+  - mount ${warp_disk_device}


### PR DESCRIPTION
# Purpose
Closes: #38 

# Contents
Autoformat & Automount Warp Disk on Warp VM startup using a cloud-init cloud config:
- auto formats `warp_disk` with btrfs is no filesystem is already present on the devices.
- adds an fstab entry to Warp VM to  automatically mount `warp_disk` on boot.

