### PR TITLE
ci(terraform): Allow GCE Machine Type to be configured on Warp VM deploy

### DIFF
--- a/.github/workflows/apply-terraform-gcp.yaml
+++ b/.github/workflows/apply-terraform-gcp.yaml
@@ -9,11 +9,23 @@ on:
   workflow_dispatch:
     inputs:
       # setting: whether to deploy the warp vm
-      deploy_warp_vm:
+      warp_vm_deploy:
         type: boolean
-        description: "Deploy WARP VM"
+        description: "Deploy WARP VM?"
         required: true
-      # config vm image used to start warp vm]
+      # warp vm machine type setting to control cpu, ram & cost of deployed vm
+      warp_vm_machine_type:
+        type: choice
+        description: "WARM VM Machine Type (CPU & RAM)"
+        required: true
+        options:
+          - "e2-tiny - 0.25CPU, 1GB"
+          - "e2-small - 0.5CPU, 2GB"
+          - "e2-medium - 1CPU, 4GB"
+          - "e2-standard-2 - 2CPU, 8GB"
+          - "e2-standard-4 - 4CPU, 16GB"
+          - "e2-standard-8 - 8CPU, 32GB"
+      # config vm image used to start warp vm
       warp_vm_image:
         type: choice
         description: "WARP VM Boot Image"
@@ -21,6 +33,7 @@ on:
         options:
           - "warp-box"
           - "warp-box-dev"
+
 jobs:
   apply-terraform-gcp:
     name: "Apply Terraform deployment on GCP"
@@ -40,6 +53,6 @@ jobs:
       - name: "Terraform Apply"
         if: ${{ github.ref == 'refs/heads/main' }}
         env:
-          TF_VAR_has_warp_vm: "${{ github.event.inputs.deploy_warp_vm }}"
+          TF_VAR_has_warp_vm: "${{ github.event.inputs.warp_vm_deploy }}"
           TF_VAR_warp_image: "${{ github.event.inputs.warp_vm_image }}"
         run: terraform apply -auto-approve

--- a/.github/workflows/apply-terraform-gcp.yaml
+++ b/.github/workflows/apply-terraform-gcp.yaml
@@ -55,4 +55,9 @@ jobs:
         env:
           TF_VAR_has_warp_vm: "${{ github.event.inputs.warp_vm_deploy }}"
           TF_VAR_warp_image: "${{ github.event.inputs.warp_vm_image }}"
-        run: terraform apply -auto-approve
+        run: |
+          terraform apply \
+            -var="warp_machine_type=$(
+              echo '${{ github.event.inputs.warp_vm_machine_type }}' | cut -d ' ' -f 1 -n
+            )"
+            -auto-approve

--- a/terraform/gcp/main.tf
+++ b/terraform/gcp/main.tf
@@ -77,7 +77,7 @@ resource "google_compute_disk" "warp_disk" {
 resource "google_compute_instance" "wrap_vm" {
   count        = var.has_warp_vm ? 1 : 0
   name         = "warp-box-vm"
-  machine_type = "e2-standard-2"
+  machine_type = var.warp_machine_type
   tags         = [local.allow_ssh_tag]
 
   boot_disk {

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -16,6 +16,12 @@ variable "warp_image" {
   default     = "warp-box"
 }
 
+variable "warp_machine_type" {
+  type        = string
+  description = "GCE machine type to use for WARP development VM"
+  default     = "e2-standard-2"
+}
+
 variable "warp_disk_size_gb" {
   type        = number
   description = "Size of the disk used mounted on the WARP development VM for persistent storage"


### PR DESCRIPTION
# Purpose
Closes: #40 

# Contents
Allow GCE Machine Type to be configured on Warp VM deploy:
- Adds `warp_machine_type` Terraform Variable to set VM machine type.
- Add dropdown to Deploy Workflow to set machine type.