### PR TITLE
feat(terraform): Allow HTTP Access to WARP VM by IP Range

### DIFF
--- a/.github/workflows/apply-terraform.yaml
+++ b/.github/workflows/apply-terraform.yaml
@@ -35,12 +35,12 @@ on:
           - "warp-box"
           - "warp-box-dev"
       # whether to enable warp vm's http web terminal
-      warp_vm_http:
+      warp_vm_http_term:
         type: boolean
         description: "WARP VM: Publicly accessible Web Terminal (HTTP)?"
         required: true
       # ip range to allow traffic to warp VM for security
-      warp_vm_allow_cidr:
+      warp_vm_allow_ip:
         type: string
         description: "WARP VM: Allow traffic from IPs (CIDR range):"
         required: true
@@ -68,6 +68,8 @@ jobs:
         env:
           TF_VAR_has_warp_vm: "${{ github.event.inputs.warp_vm_deploy }}"
           TF_VAR_warp_image: "${{ github.event.inputs.warp_vm_image }}"
+          TF_VAR_warp_http_terminal: "${{ github.event.inputs.warp_vm_http_term }}"
+          TF_VAR_warp_allow_ip: "{{ github.event.inputsf.warp_vm_allow_ip }}"
           # use LetsEncrypt's production server to issue trusted TLS certificates
           TF_VAR_acme_server_url: "https://acme-v02.api.letsencrypt.org/directory"
         run: >

--- a/.github/workflows/apply-terraform.yaml
+++ b/.github/workflows/apply-terraform.yaml
@@ -8,6 +8,7 @@ name: "Deploy Terraform"
 on:
   workflow_dispatch:
     inputs:
+      # WARP VM inputs
       # setting: whether to deploy the warp vm
       warp_vm_deploy:
         type: boolean
@@ -25,7 +26,7 @@ on:
           - "e2-standard-2 - 2CPU, 8GB"
           - "e2-standard-4 - 4CPU, 16GB"
           - "e2-standard-8 - 8CPU, 32GB"
-      # config vm image used to start warp vm
+      # set vm image used to start warp vm
       warp_vm_image:
         type: choice
         description: "WARP VM Boot Image"
@@ -33,6 +34,18 @@ on:
         options:
           - "warp-box"
           - "warp-box-dev"
+      # whether to enable warp vm's http web terminal
+      warp_vm_http:
+        type: boolean
+        description: "WARP VM publicly accessible Web Terminal (HTTP)?"
+        required: true
+      # ip range to allow traffic to warp VM for security
+      warp_vm_allow_cidr:
+        type: string
+        description: "WARP VM limit traffic to IP CIDR range"
+        required: true
+        # by default, allow traffic from all ip addresses
+        default: "0.0.0.0/0"
 
 jobs:
   apply-terraform:

--- a/.github/workflows/apply-terraform.yaml
+++ b/.github/workflows/apply-terraform.yaml
@@ -12,12 +12,12 @@ on:
       # setting: whether to deploy the warp vm
       warp_vm_deploy:
         type: boolean
-        description: "Deploy WARP VM?"
+        description: "WARP VM: Deploy?"
         required: true
       # warp vm machine type setting to control cpu, ram & cost of deployed vm
       warp_vm_machine_type:
         type: choice
-        description: "WARM VM Machine Type (CPU & RAM)"
+        description: "WARM VM: Machine Type (CPU & RAM)"
         required: true
         options:
           - "e2-micro - 0.25CPU, 1GB"
@@ -29,7 +29,7 @@ on:
       # set vm image used to start warp vm
       warp_vm_image:
         type: choice
-        description: "WARP VM Boot Image"
+        description: "WARP VM: Boot Image"
         required: true
         options:
           - "warp-box"
@@ -37,12 +37,12 @@ on:
       # whether to enable warp vm's http web terminal
       warp_vm_http:
         type: boolean
-        description: "WARP VM publicly accessible Web Terminal (HTTP)?"
+        description: "WARP VM: Publicly accessible Web Terminal (HTTP)?"
         required: true
       # ip range to allow traffic to warp VM for security
       warp_vm_allow_cidr:
         type: string
-        description: "WARP VM limit traffic to IP CIDR range"
+        description: "WARP VM: Allow traffic from IPs (CIDR range):"
         required: true
         # by default, allow traffic from all ip addresses
         default: "0.0.0.0/0"

--- a/.github/workflows/apply-terraform.yaml
+++ b/.github/workflows/apply-terraform.yaml
@@ -69,7 +69,7 @@ jobs:
           TF_VAR_has_warp_vm: "${{ github.event.inputs.warp_vm_deploy }}"
           TF_VAR_warp_image: "${{ github.event.inputs.warp_vm_image }}"
           TF_VAR_warp_http_terminal: "${{ github.event.inputs.warp_vm_http_term }}"
-          TF_VAR_warp_allow_ip: "{{ github.event.inputsf.warp_vm_allow_ip }}"
+          TF_VAR_warp_allow_ip: "{{ github.event.inputs.warp_vm_allow_ip }}"
           # use LetsEncrypt's production server to issue trusted TLS certificates
           TF_VAR_acme_server_url: "https://acme-v02.api.letsencrypt.org/directory"
         run: >

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -73,8 +73,8 @@ module "gce" {
   source = "./modules/gce"
 
   ingress_allows = {
-    (local.allow_ssh_tag)   = 22
-    (local.allow_https_tag) = 443
+    (local.allow_ssh_tag)   = ["0.0.0.0/0", 22]
+    (local.allow_https_tag) = ["0.0.0.0/0", 443]
   }
 }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -92,16 +92,9 @@ module "warp_vm" {
   ]
   disk_size_gb = var.warp_disk_size_gb
 
-  web_tls_cert = (
-    length(var.warp_web_tls_cert) > 0 ? var.warp_web_tls_cert :
-    module.tls_cert.full_chain_cert
-  )
-  web_tls_key = (
-    length(var.warp_web_tls_key) > 0 ? var.warp_web_tls_key :
-    module.tls_cert.full_chain_key
-  )
+  web_tls_cert = module.tls_cert.full_chain_cert
+  web_tls_key  = module.tls_cert.private_key
 }
-
 locals {
   warp_ip = (
     module.warp_vm.external_ip == null ?

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -75,9 +75,9 @@ module "gce" {
   source = "./modules/gce"
 
   ingress_allows = {
-    (local.allow_ssh_tag)       = ["0.0.0.0/0", 22]
-    (local.allow_https_tag)     = ["0.0.0.0/0", 443]
-    (local.warp_allow_http_tag) = [var.warp_allow_ip, 80]
+    (local.allow_ssh_tag)       = ["0.0.0.0/0", "22"]
+    (local.allow_https_tag)     = ["0.0.0.0/0", "443"]
+    (local.warp_allow_http_tag) = [var.warp_allow_ip, "80"]
   }
 }
 

--- a/terraform/modules/gce/main.tf
+++ b/terraform/modules/gce/main.tf
@@ -30,9 +30,9 @@ resource "google_compute_firewall" "sandbox" {
   direction = "INGRESS"
   allow {
     protocol = "tcp"
-    ports    = ["${each.value}"]
+    ports    = ["${each.value[1]}"]
   }
-  source_ranges = ["0.0.0.0/0"]
+  source_ranges = ["${each.value[0]}"]
   target_tags   = [each.key]
 }
 

--- a/terraform/modules/gce/variables.tf
+++ b/terraform/modules/gce/variables.tf
@@ -5,10 +5,12 @@
 #
 
 variable "ingress_allows" {
-  type        = map(number)
+  type        = map(list(string))
   description = <<-EOF
-  List of ingress allow rules to create the firewall as map of <tag> = <port>.
-  This allows ingress traffic from the internet to the specified port on
-  GCE instances tagged with the specified GCE Metadata tag.
+  List of ingress allow rules to create the firewall.
+  Expressed as map of <tag> = [<cidr>, <port>].
+
+  This allows ingress traffic from the IPs in the CIDR range to the specified
+  port on GCE instances tagged with the specified GCE Metadata tag.
   EOF
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -27,29 +27,6 @@ variable "warp_disk_size_gb" {
   default     = 10
 }
 
-variable "warp_web_tls_cert" {
-  type        = string
-  description = <<-EOF
-  Full chain TLS certificate used to verify WARP VM identity when connecting
-  via its Web Terminal. The certificate should be encoded in the PEM format.
-
-  By default, uses a ACME server issued TLS certificate.
-  EOF
-  default     = ""
-}
-
-variable "warp_web_tls_key" {
-  type        = string
-  sensitive   = true
-  description = <<-EOF
-  Private key of the TLS certificate used by the WARP VM's Web Terminal.
-  The private key should be encoded in the PEM format.
-
-  By default, users the private key of the ACME server issued TLS certificate.
-  EOF
-  default     = ""
-}
-
 variable "gcp_service_account_key" {
   type        = string
   sensitive   = true

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -27,6 +27,18 @@ variable "warp_disk_size_gb" {
   default     = 10
 }
 
+variable "warp_http_terminal" {
+  type        = bool
+  description = "Whether to enable the publicly accessible HTTP web terminal on WARP VM."
+  default     = false
+}
+
+variable "warp_allow_ip" {
+  type        = string
+  description = "Allow traffic to WARP VM from the given IP range in CIDR notation."
+  default     = "0.0.0.0/0"
+}
+
 variable "gcp_service_account_key" {
   type        = string
   sensitive   = true


### PR DESCRIPTION
# Purpose
Closes: #46 

# Contents
Allow HTTP Access to WARP VM by IP Range:
- Add Deploy Terraform workflow inputs as defined in #46.
- Update Terraform to support new workflow inputs.