### PR TITLE
feat(terraform): Allow user to expose arbitary Ports on WARP for Development

### DIFF
--- a/.github/workflows/apply-terraform.yaml
+++ b/.github/workflows/apply-terraform.yaml
@@ -34,11 +34,12 @@ on:
         options:
           - "warp-box"
           - "warp-box-dev"
-      # whether to enable warp vm's development port
-      warp_vm_dev_port:
-        type: boolean
-        description: "WARP VM: Expose WARP VM's development port (8080)?"
+      # list of comma separate ports to open on warp vm for development purposes
+      warm_vm_allow_ports:
+        type: string
+        description: "WARP VM: Comma-separated ports to expose"
         required: true
+        default: ""
       # whether to enable warp vm's http web terminal
       warp_vm_http_term:
         type: boolean
@@ -73,7 +74,7 @@ jobs:
         env:
           TF_VAR_has_warp_vm: "${{ github.event.inputs.warp_vm_deploy }}"
           TF_VAR_warp_image: "${{ github.event.inputs.warp_vm_image }}"
-          TF_VAR_warp_allow_dev_port: "${{ github.event.inputs.warp_vm_dev_port }}"
+          TF_VAR_warp_allow_ports: "${{ github.event.inputs.warp_vm_allow_ports }}"
           TF_VAR_warp_http_terminal: "${{ github.event.inputs.warp_vm_http_term }}"
           TF_VAR_warp_allow_ip: "${{ github.event.inputs.warp_vm_allow_ip }}"
           # use LetsEncrypt's production server to issue trusted TLS certificates

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -104,7 +104,7 @@ module "vpc" {
     },
     # create allow rules for WARP VM development ports
     {
-      for port in split(",", var.warp_allow_ports) :
+      for port in compact(split(",", var.warp_allow_ports)) :
       "warp-dev-${trim(port, " ")}" => {
         "tag"  = local.warp_allow_dev_tag,
         "cidr" = var.warp_allow_ip,

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -85,10 +85,26 @@ module "vpc" {
   source = "./modules/gcp/vpc"
 
   ingress_allows = {
-    (local.allow_ssh_tag)       = ["0.0.0.0/0", "22"]
-    (local.allow_https_tag)     = ["0.0.0.0/0", "443"]
-    (local.warp_allow_http_tag) = [var.warp_allow_ip, "80"]
-    (local.warp_allow_dev_tag)  = [var.warp_allow_ip, "8080"]
+    "ssh" = {
+      "tag"  = local.allow_ssh_tag,
+      "cidr" = "0.0.0.0/0",
+      "port" = "22",
+    },
+    "https" = {
+      "tag"  = local.allow_https_tag,
+      "cidr" = "0.0.0.0/0",
+      "port" = "443",
+    },
+    "http" = {
+      "tag"  = local.warp_allow_http_tag,
+      "cidr" = var.warp_allow_ip,
+      "port" = "80",
+    },
+    "dev" = {
+      "tag"  = local.warp_allow_dev_tag,
+      "cidr" = var.warp_allow_ip,
+      "port" = "8080",
+    },
   }
 }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -84,28 +84,34 @@ module "tls_cert" {
 module "vpc" {
   source = "./modules/gcp/vpc"
 
-  ingress_allows = {
-    "ssh" = {
-      "tag"  = local.allow_ssh_tag,
-      "cidr" = "0.0.0.0/0",
-      "port" = "22",
+  ingress_allows = merge(
+    {
+      "ssh" = {
+        "tag"  = local.allow_ssh_tag,
+        "cidr" = "0.0.0.0/0",
+        "port" = "22",
+      },
+      "https" = {
+        "tag"  = local.allow_https_tag,
+        "cidr" = "0.0.0.0/0",
+        "port" = "443",
+      },
+      "warp-http" = {
+        "tag"  = local.warp_allow_http_tag,
+        "cidr" = var.warp_allow_ip,
+        "port" = "80",
+      },
     },
-    "https" = {
-      "tag"  = local.allow_https_tag,
-      "cidr" = "0.0.0.0/0",
-      "port" = "443",
-    },
-    "http" = {
-      "tag"  = local.warp_allow_http_tag,
-      "cidr" = var.warp_allow_ip,
-      "port" = "80",
-    },
-    "dev" = {
-      "tag"  = local.warp_allow_dev_tag,
-      "cidr" = var.warp_allow_ip,
-      "port" = "8080",
-    },
-  }
+    # create allow rules for WARP VM development ports
+    {
+      for port in split(",", var.warp_allow_ports) :
+      "warp-dev-${trim(port, " ")}" => {
+        "tag"  = local.warp_allow_dev_tag,
+        "cidr" = var.warp_allow_ip,
+        "port" = trim(port, " "),
+      }
+    }
+  )
 }
 
 # Deploy WARP Box development VM on GCP
@@ -120,11 +126,10 @@ module "warp_vm" {
     [
       local.allow_ssh_tag,
       local.allow_https_tag,
+      local.warp_allow_dev_tag,
     ],
     # allow http for warp vm's http terminal if enabled
     var.warp_http_terminal ? [local.warp_allow_http_tag] : [],
-    # expose warp vm dev port if enabled
-    var.warp_allow_dev_port ? [local.warp_allow_dev_tag] : []
   )
   disk_size_gb = var.warp_disk_size_gb
 

--- a/terraform/modules/gcp/vpc/main.tf
+++ b/terraform/modules/gcp/vpc/main.tf
@@ -25,13 +25,16 @@ resource "google_compute_firewall" "sandbox" {
 
   name        = each.key
   network     = google_compute_network.sandbox.self_link
-  description = "Allow ingress traffic to instances tagged with '${each.key}' tag."
+  description = <<-EOF
+    Allow ingress traffic to port ${each.value["port"]} on instances
+    tagged with '${each.value["tag"]}' tag."
+  EOF
 
   direction = "INGRESS"
   allow {
     protocol = "tcp"
-    ports    = ["${each.value[1]}"]
+    ports    = ["${each.value["port"]}"]
   }
-  source_ranges = ["${each.value[0]}"]
-  target_tags   = [each.key]
+  source_ranges = ["${each.value["cidr"]}"]
+  target_tags   = [each.value["tag"]]
 }

--- a/terraform/modules/gcp/vpc/variables.tf
+++ b/terraform/modules/gcp/vpc/variables.tf
@@ -5,10 +5,14 @@
 #
 
 variable "ingress_allows" {
-  type        = map(list(string))
+  type        = map(map(string))
   description = <<-EOF
   List of ingress allow rules to create the firewall.
-  Expressed as map of <tag> = [<cidr>, <port>].
+  Expressed as map of id = {
+    tag = <tag>,
+    cidr = <cidr>,
+    port= <port>
+  }.
 
   This allows ingress traffic from the IPs in the CIDR range to the specified
   port on GCE instances tagged with the specified GCE Metadata tag.

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -43,7 +43,7 @@ variable "warp_allow_ip" {
 variable "warp_allow_ports" {
   type        = string
   description = "Addditional Comma-seperated ports to enable on WARP VM for development purposes."
-  default     = "69, 8888"
+  default     = ""
 }
 
 variable "gcp_service_account_key" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -42,7 +42,7 @@ variable "warp_allow_ip" {
 
 variable "warp_allow_ports" {
   type        = string
-  description = "Addditional Comma-seperated ports to enable on WARP VM for development purposes."
+  description = "Additional Comma-seperated ports to enable on WARP VM for development purposes."
   default     = ""
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -40,13 +40,10 @@ variable "warp_allow_ip" {
   default     = "0.0.0.0/0"
 }
 
-variable "warp_allow_dev_port" {
-  type        = bool
-  description = <<-EOF
-    Whether to expose port 8080 to allow access to a development server for testing.
-    Example: Access development web server on port 8080 when doing Web API development.
-  EOF
-  default     = false
+variable "warp_allow_ports" {
+  type        = string
+  description = "Addditional Comma-seperated ports to enable on WARP VM for development purposes."
+  default     = "69, 8888"
 }
 
 variable "gcp_service_account_key" {


### PR DESCRIPTION
# Motivation
Since WARP VM is meant to be used a development machine, there is often a need to access ports on WARP VM for development purposes:
- access Jupyter Notebook server when performing data science experiments.
- test development server when a Web Frontend, API service.
- etc.

Currently WARP VM only allows users to expose port 8080 for development (197ce5c3c1f7ac0d11d093deba48eb625efdb952).

# Contents
Allow user to expose arbitary Ports on WARP for Development:
- users can now specify a list of comma delimited ports to expose on WARP VM: (eg. `8080, 8888`)
- refactor's GCP VPC module `ingress_rules` to support same tag, multiple firewall rules needed for the above.