### PR TITLE
feat(terraform): Persist docker volumes in WARP VM's Persistent Disk

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -21,6 +21,26 @@ provider "registry.terraform.io/hashicorp/google" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version     = "2.12.1"
+  constraints = "2.12.1"
+  hashes = [
+    "h1:6ZgqegUao9WcfVzYg7taxCQOQldTmMVw0HqjG5S46OY=",
+    "zh:1ecb2adff52754fb4680c7cfe6143d1d8c264b00bb0c44f07f5583b1c7f978b8",
+    "zh:1fbd155088cd5818ad5874e4d59ccf1801e4e1961ac0711442b963315f1967ab",
+    "zh:29e927c7c8f112ee0e8ab70e71b498f2f2ae6f47df1a14e6fd0fdb6f14b57c00",
+    "zh:42c2f421da6b5b7c997e42aa04ca1457fceb13dd66099a057057a0812b680836",
+    "zh:522a7bccd5cd7acbb4ec3ef077d47f4888df7e59ff9f3d598b717ad3ee4fe9c9",
+    "zh:b45d8dc5dcbc5e30ae570d0c2e198505f47d09098dfd5f004871be8262e6ec1e",
+    "zh:c3ea0943f2050001c7d6a7115b9b990f148b082ebfc4ff3c2ff3463a8affcc4a",
+    "zh:f111833a64e06659d2e21864de39b7b7dec462615294d02f04c777956742a930",
+    "zh:f182dba5707b90b0952d5984c23f7a2da3baa62b4d71e78df7759f16cc88d957",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f76655a68680887daceabd947b2f68e2103f5bbec49a2bc29530f82ab8e3bca3",
+    "zh:fadb77352caa570bd3259dfb59c31db614d55bc96df0ff15a3c0cd2e685678b9",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/tls" {
   version     = "3.4.0"
   constraints = ">= 3.4.0, < 3.5.0"

--- a/terraform/modules/gcp/warp_vm/main.tf
+++ b/terraform/modules/gcp/warp_vm/main.tf
@@ -87,6 +87,7 @@ resource "google_compute_instance" "wrap_vm" {
     # user data is used by cloud-init to provision the system
     user-data = templatefile("${path.module}/templates/cloud_init.yaml", {
       warp_disk_device = "/dev/disk/by-id/google-${local.warp_disk_id}"
+      mountpoint       = "/home/mrzzy/disk"
       ttyd_cert_base64 = base64encode(var.web_tls_cert)
       ttyd_key_base64  = base64encode(var.web_tls_key)
     })

--- a/terraform/modules/gcp/warp_vm/templates/cloud_init.yaml
+++ b/terraform/modules/gcp/warp_vm/templates/cloud_init.yaml
@@ -1,5 +1,4 @@
 #cloud-config
-# TODO(mrzzy): template mount point
 bootcmd:
   # format warp's persisent disk with btrfs
   # verify that no fs exists on device before formatting
@@ -7,7 +6,7 @@ bootcmd:
     test -z "$(blkid ${warp_disk_device})" &&
       mkfs.btrfs -L warp_disk ${warp_disk_device}
   # create mountpoint for warp's persisent disk
-  - mkdir -p /home/mrzzy/disk
+  - mkdir -p ${mountpoint}
 
 write_files:
 # write TLS certificate & private key for the TTYD web terminal
@@ -23,14 +22,14 @@ write_files:
 
 mounts:
   # fstab entry to mount warp disk
-  - ["${warp_disk_device}", "/home/mrzzy/disk", "btrfs", "defaults", "0", "2"]
+  - ["${warp_disk_device}", "${mountpoint}", "btrfs", "defaults", "0", "2"]
 
 runcmd:
   # create & mount btrfs subvolume to persist docker volumes in warp's persisent disk
   - systemctl stop docker
-  - btrfs subvolume create /home/mrzzy/disk/docker_volumes
+  - btrfs subvolume create ${mountpoint}/docker_volumes
   - mount -t btrfs -o subvolume=docker_volumes ${warp_disk_device} /var/lib/docker/volumes
   - systemctl start docker
 
   # ensure warp disk is writeable by making the mrzzy user owner
-  - chown -R mrzzy:mrzzy /home/mrzzy/disk
+  - chown -R mrzzy:mrzzy ${mountpoint}

--- a/terraform/modules/gcp/warp_vm/templates/cloud_init.yaml
+++ b/terraform/modules/gcp/warp_vm/templates/cloud_init.yaml
@@ -1,11 +1,12 @@
 #cloud-config
+# TODO(mrzzy): template mount point
 bootcmd:
   # format warp's persisent disk with btrfs
   # verify that no fs exists on device before formatting
   - >-
     test -z "$(blkid ${warp_disk_device})" &&
-      mkfs.btrfs -L warp_disk ${ warp_disk_device }
-  # create mountpoint
+      mkfs.btrfs -L warp_disk ${warp_disk_device}
+  # create mountpoint for warp's persisent disk
   - mkdir -p /home/mrzzy/disk
 
 write_files:
@@ -25,5 +26,11 @@ mounts:
   - ["${warp_disk_device}", "/home/mrzzy/disk", "btrfs", "defaults", "0", "2"]
 
 runcmd:
+  # create & mount btrfs subvolume to persist docker volumes in warp's persisent disk
+  - systemctl stop docker
+  - btrfs subvolume create /home/mrzzy/disk/docker_volumes
+  - mount -t btrfs -o subvolume=docker_volumes ${warp_disk_device} /var/lib/docker/volumes
+  - systemctl start docker
+
   # ensure warp disk is writeable by making the mrzzy user owner
   - chown -R mrzzy:mrzzy /home/mrzzy/disk

--- a/terraform/modules/gcp/warp_vm/templates/cloud_init.yaml
+++ b/terraform/modules/gcp/warp_vm/templates/cloud_init.yaml
@@ -28,7 +28,7 @@ runcmd:
   # create & mount btrfs subvolume to persist docker volumes in warp's persisent disk
   - systemctl stop docker
   - btrfs subvolume create ${mountpoint}/docker_volumes
-  - mount -t btrfs -o subvolume=docker_volumes ${warp_disk_device} /var/lib/docker/volumes
+  - mount -t btrfs -o subvol=docker_volumes ${warp_disk_device} /var/lib/docker/volumes
   - systemctl start docker
 
   # ensure warp disk is writeable by making the mrzzy user owner

--- a/terraform/modules/linode/k8s/main.tf
+++ b/terraform/modules/linode/k8s/main.tf
@@ -9,6 +9,10 @@ terraform {
       source  = "linode/linode"
       version = ">=1.28.0, <1.29.0"
     }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "2.12.1"
+    }
   }
 }
 
@@ -22,4 +26,17 @@ resource "linode_lke_cluster" "main" {
     type  = var.machine_type
     count = 1
   }
+}
+
+# Configure Terraform provider for Kubernetes to access K8s on Linode
+locals {
+  kubeconfig = yamldecode(base64decode(linode_lke_cluster.main.kubeconfig))
+}
+provider "kubernetes" {
+  host = linode_lke_cluster.main.api_endpoints[0]
+
+  token = one(local.kubeconfig["users"])["user"]["token"]
+  cluster_ca_certificate = base64decode(
+    one(local.kubeconfig["clusters"])["cluster"]["certificate-authority-data"]
+  )
 }


### PR DESCRIPTION
# Purpose
Every time WARP VM restarts, data stored in Docker Volumes is lost:
- **cause:** Docker Volumes is stored outside of the WARP persistent disk mounted at `/home/mrzzy/disk` at `/var/lib/docker/volumes`.


# Contents
Persist docker volumes in WARP VM's Persistent Disk:
- create & mount a BtrFS subvolume that stores data in the WARP persistent disk at `/var/lib/docker/volumes` to capture docker volumes created by docker.
- docker is stopped & started during the mount to ensure:
  1. no race condition manipulating path `/var/lib/docker/volumes` between docker and the mount.
  2. docker's in-memory volume cache is flushed.

Refactor: Template `/home/mrzzy/disk` instead of copying multiple times in the cloud-init.yaml template.
 
