### PR TITLE
feat(terraform): Refactor & Add Backblaze B2 Terraform Provider

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,6 +1,18 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/backblaze/b2" {
+  version     = "0.8.1"
+  constraints = "0.8.1"
+  hashes = [
+    "h1:8RfNGddgJ5Xu9LcA9UtzXtVV87a1UxUEWTy9+83Czoo=",
+    "zh:2f4ffb6cbc1bdae18a71a9b9b2b3563c2109a31b409077bf32e0bdc5c1980605",
+    "zh:87395bf0c2951770b9a764b55ccf2ac630d064219c09d6b4fad8ab0c81d6bbe9",
+    "zh:c2cf5f8f349f6484ab19d3b43d9952d299ef6128a9c0b0c81c3d87c0a9bbbd97",
+    "zh:f080728e857503e2dbda3f56f2b3154aae99ef0f0ef9d81163018e59c1313e1b",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/google" {
   version     = "4.22.0"
   constraints = ">= 4.22.0, < 4.23.0"

--- a/terraform/gcp.tf
+++ b/terraform/gcp.tf
@@ -1,0 +1,94 @@
+#
+# Nimbus
+# Google Cloud Deployment
+#
+
+locals {
+  # GCP project
+  gcp_project_id = "mrzzy-sandbox"
+
+  # GCE tags for firewall rules
+  allow_ssh_tag       = "allow-ssh"
+  allow_https_tag     = "allow-https"
+  warp_allow_http_tag = "warp-allow-http"
+  warp_allow_dev_tag  = "warp-allow-dev"
+
+  # mrzzy's SSH public key
+  ssh_public_key = "mrzzy:ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBrfd982D9iQVTe2VecUncbgysh/XsZb4YyOhCSSAAtr mrzzy"
+}
+provider "google" {
+  project = local.gcp_project_id
+  region  = "asia-southeast1" # singapore
+  zone    = "asia-southeast1-c"
+}
+
+# GCP: Shared IAM resources
+module "iam" {
+  source = "./modules/gcp/iam"
+
+  project = local.gcp_project_id
+}
+
+# GCP: Shared VPC network VM instances reside on
+module "vpc" {
+  source = "./modules/gcp/vpc"
+
+  ingress_allows = merge(
+    {
+      "ssh" = {
+        "tag"  = local.allow_ssh_tag,
+        "cidr" = "0.0.0.0/0",
+        "port" = "22",
+      },
+      "https" = {
+        "tag"  = local.allow_https_tag,
+        "cidr" = "0.0.0.0/0",
+        "port" = "443",
+      },
+      "warp-http" = {
+        "tag"  = local.warp_allow_http_tag,
+        "cidr" = var.warp_allow_ip,
+        "port" = "80",
+      },
+    },
+    # create allow rules for WARP VM development ports
+    {
+      for port in compact(split(",", var.warp_allow_ports)) :
+      "warp-dev-${trim(port, " ")}" => {
+        "tag"  = local.warp_allow_dev_tag,
+        "cidr" = var.warp_allow_ip,
+        "port" = trim(port, " "),
+      }
+    }
+  )
+}
+
+# GCP: Deploy WARP Box development VM on GCP
+# https://github.com/mrzzy/warp
+module "warp_vm" {
+  source = "./modules/gcp/warp_vm"
+
+  enabled      = var.has_warp_vm
+  image        = var.warp_image
+  machine_type = var.warp_machine_type
+  tags = concat(
+    [
+      local.allow_ssh_tag,
+      local.allow_https_tag,
+      local.warp_allow_dev_tag,
+    ],
+    # allow http for warp vm's http terminal if enabled
+    var.warp_http_terminal ? [local.warp_allow_http_tag] : [],
+  )
+  disk_size_gb = var.warp_disk_size_gb
+
+  web_tls_cert   = module.tls_cert.full_chain_cert
+  web_tls_key    = module.tls_cert.private_key
+  ssh_public_key = local.ssh_public_key
+}
+
+# GCP: enroll project-wide ssh key for ssh access to VMs
+resource "google_compute_project_metadata_item" "ssh_keys" {
+  key   = "ssh-keys"
+  value = local.ssh_public_key
+}

--- a/terraform/linode.tf
+++ b/terraform/linode.tf
@@ -1,0 +1,55 @@
+#
+# Nimbus
+# Linode Terraform Deployment
+#
+
+locals {
+  domain      = "mrzzy.co"
+  domain_slug = replace(local.domain, ".", "-")
+
+  # Linode deploy region
+  linode_region = "ap-south" # singapore
+}
+
+# Linode Cloud
+provider "linode" {}
+
+# Linode: LKE Cluster
+module "k8s" {
+  source = "./modules/linode/k8s"
+  region = local.linode_region
+
+  machine_type = "g6-standard-2" # 2vCPU, 2GB
+  n_workers    = 1
+
+  # TLS credentials to add to the cluster as K8s secrets.
+  tls_certs = {
+    "${local.domain_slug}-tls" = {
+      "cert" = module.tls_cert.full_chain_cert,
+    }
+  }
+  tls_keys = {
+    "${local.domain_slug}-tls" = module.tls_cert.private_key,
+  }
+}
+
+# Linode: DNS zone & routes for mrzzy.co domain
+locals {
+  warp_ip = (
+    # TODO(mrzzy): this conditional seems to do nothing, can we remove it?
+    module.warp_vm.external_ip == null ? null : module.warp_vm.external_ip
+  )
+}
+module "dns" {
+  source = "./modules/linode/dns"
+
+  domain = "mrzzy.co"
+  routes = merge({
+    # dns routes for services served by k8s's ingress
+    "auth" : module.k8s.ingress_ip,  # oauth2-proxy oauth callbacks / login page
+    "media" : module.k8s.ingress_ip, # jellyfin media server
+    },
+    # only create dns route for WARP VM if its deployed
+    var.has_warp_vm ? { "warp" : local.warp_ip } : {},
+  )
+}

--- a/terraform/linode.tf
+++ b/terraform/linode.tf
@@ -40,7 +40,7 @@ locals {
 module "dns" {
   source = "./modules/linode/dns"
 
-  domain = "mrzzy.co"
+  domain = local.domain
   routes = merge({
     # dns routes for services served by k8s's ingress
     "auth" : module.k8s.ingress_ip,  # oauth2-proxy oauth callbacks / login page

--- a/terraform/linode.tf
+++ b/terraform/linode.tf
@@ -35,10 +35,7 @@ module "k8s" {
 
 # Linode: DNS zone & routes for mrzzy.co domain
 locals {
-  warp_ip = (
-    # TODO(mrzzy): this conditional seems to do nothing, can we remove it?
-    module.warp_vm.external_ip == null ? null : module.warp_vm.external_ip
-  )
+  warp_ip = module.warp_vm.external_ip
 }
 module "dns" {
   source = "./modules/linode/dns"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -19,6 +19,10 @@ terraform {
       source  = "vancluever/acme"
       version = ">=2.9.0, <2.10.0"
     }
+    b2 = {
+      source  = "Backblaze/b2"
+      version = "0.8.1"
+    }
   }
 
   # terraform cloud workspace to store terraform state
@@ -41,3 +45,6 @@ module "tls_cert" {
   common_name = local.domain
   domains     = ["*.${local.domain}"]
 }
+
+# Backblaze B2 Cloud Storage provider
+provider "b2" {}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -3,25 +3,6 @@
 # Terraform Deployment
 #
 
-locals {
-  domain      = "mrzzy.co"
-  domain_slug = replace(local.domain, ".", "-")
-
-  # GCP project
-  gcp_project_id = "mrzzy-sandbox"
-  # GCE tags for firewall rules
-  allow_ssh_tag       = "allow-ssh"
-  allow_https_tag     = "allow-https"
-  warp_allow_http_tag = "warp-allow-http"
-  warp_allow_dev_tag  = "warp-allow-dev"
-
-  # Linode deploy region
-  linode_region = "ap-south" # singapore
-
-  # mrzzy's SSH public key
-  ssh_public_key = "mrzzy:ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBrfd982D9iQVTe2VecUncbgysh/XsZb4YyOhCSSAAtr mrzzy"
-}
-
 terraform {
   required_version = ">=1.2.0, <1.3.0"
 
@@ -49,136 +30,14 @@ terraform {
     }
   }
 }
-
-# Google Cloud Platform
-provider "google" {
-  project = local.gcp_project_id
-  region  = "asia-southeast1" # singapore
-  zone    = "asia-southeast1-c"
-}
-
-# Linode Cloud
-provider "linode" {}
-
-
 # Lets Encrypt ACME TLS certificate issuer
 provider "acme" {
   server_url = var.acme_server_url
 }
-
-# GCP: Shared IAM resources
-module "iam" {
-  source = "./modules/gcp/iam"
-
-  project = local.gcp_project_id
-}
-
 # Issue trusted wildcard TLS certificate for domain via ACME
 module "tls_cert" {
   source = "./modules/linode/tls_acme"
 
   common_name = local.domain
   domains     = ["*.${local.domain}"]
-}
-
-# GCP: Shared VPC network VM instances reside on
-module "vpc" {
-  source = "./modules/gcp/vpc"
-
-  ingress_allows = merge(
-    {
-      "ssh" = {
-        "tag"  = local.allow_ssh_tag,
-        "cidr" = "0.0.0.0/0",
-        "port" = "22",
-      },
-      "https" = {
-        "tag"  = local.allow_https_tag,
-        "cidr" = "0.0.0.0/0",
-        "port" = "443",
-      },
-      "warp-http" = {
-        "tag"  = local.warp_allow_http_tag,
-        "cidr" = var.warp_allow_ip,
-        "port" = "80",
-      },
-    },
-    # create allow rules for WARP VM development ports
-    {
-      for port in compact(split(",", var.warp_allow_ports)) :
-      "warp-dev-${trim(port, " ")}" => {
-        "tag"  = local.warp_allow_dev_tag,
-        "cidr" = var.warp_allow_ip,
-        "port" = trim(port, " "),
-      }
-    }
-  )
-}
-
-# GCP: Deploy WARP Box development VM on GCP
-# https://github.com/mrzzy/warp
-module "warp_vm" {
-  source = "./modules/gcp/warp_vm"
-
-  enabled      = var.has_warp_vm
-  image        = var.warp_image
-  machine_type = var.warp_machine_type
-  tags = concat(
-    [
-      local.allow_ssh_tag,
-      local.allow_https_tag,
-      local.warp_allow_dev_tag,
-    ],
-    # allow http for warp vm's http terminal if enabled
-    var.warp_http_terminal ? [local.warp_allow_http_tag] : [],
-  )
-  disk_size_gb = var.warp_disk_size_gb
-
-  web_tls_cert   = module.tls_cert.full_chain_cert
-  web_tls_key    = module.tls_cert.private_key
-  ssh_public_key = local.ssh_public_key
-}
-locals {
-  warp_ip = (
-    module.warp_vm.external_ip == null ? null : module.warp_vm.external_ip
-  )
-}
-# GCP: enroll project-wide ssh key for ssh access to VMs
-resource "google_compute_project_metadata_item" "ssh_keys" {
-  key   = "ssh-keys"
-  value = "mrzzy:ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBrfd982D9iQVTe2VecUncbgysh/XsZb4YyOhCSSAAtr mrzzy"
-}
-
-# Linode: LKE Cluster
-module "k8s" {
-  source = "./modules/linode/k8s"
-  region = local.linode_region
-
-  machine_type = "g6-standard-2" # 2vCPU, 2GB
-  n_workers    = 1
-
-  # TLS credentials to add to the cluster as K8s secrets.
-  tls_certs = {
-    "${local.domain_slug}-tls" = {
-      "cert" = module.tls_cert.full_chain_cert,
-    }
-  }
-  tls_keys = {
-    "${local.domain_slug}-tls" = module.tls_cert.private_key,
-  }
-}
-
-# Linode: DNS zone & routes for mrzzy.co domain
-module "dns" {
-  source = "./modules/linode/dns"
-
-  domain = "mrzzy.co"
-  routes = merge({
-    # dns routes for services served by k8s's ingress
-    "auth" : module.k8s.ingress_ip,  # oauth2-proxy oauth callbacks / login page
-    "media" : module.k8s.ingress_ip, # jellyfin media server
-    },
-    # only create dns route for WARP VM if its deployed
-    var.has_warp_vm ? { "warp" : local.warp_ip } : {},
-  )
 }


### PR DESCRIPTION
# Purpose
Manage Backblaze B2 buckets with Terraform for:
- storing media in #48 
- off-site backup storage location.

# Contents
Add Backblaze B2 Terraform Provider:
Refactor: splits `main.tf` into `linode.tf` & `gcp.tf` along Cloud Provider Lines.