### PR TITLE
refactor(media): Switch to Backblaze B2 Bucket for Media File Storage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,3 +34,5 @@ repos:
     args:
       - --args=-recursive -no-color
   - id: terraform_validate
+    args:
+      - --args=-no-color

--- a/k8s/base/csi-s3/kustomization.yaml
+++ b/k8s/base/csi-s3/kustomization.yaml
@@ -19,16 +19,17 @@ commonLabels:
 # https://github.com/ctrox/csi-s3/pull/70/files
 patchesJson6902:
   - target:
+      group: rbac.authorization.k8s.io
+      version: v1
       kind: ClusterRole
       name: external-attacher-runner
-      version: rbac.authorization.k8s.io/v1
     patch: |-
       - op: add
-        path: /rules
+        path: /rules/1
         value:
-          apiGroups: ["storage.k8s.io"]
-          resources: ["volumeattachments/status"]
-          verbs: ["patch"]
+         apiGroups: ["storage.k8s.io"]
+         resources: ["volumeattachments/status"]
+         verbs: ["patch"]
 images:
   - name: quay.io/k8scsi/csi-attacher
     newTag: v3.1.0

--- a/k8s/base/csi-s3/kustomization.yaml
+++ b/k8s/base/csi-s3/kustomization.yaml
@@ -1,0 +1,34 @@
+#
+# Nimbus
+# CSI S3 Kustomization
+#
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+resources:
+  # S3 CSI - Persistent Volume Provisioner
+  - https://raw.githubusercontent.com/ctrox/csi-s3/v1.2.0-rc.2/deploy/kubernetes/attacher.yaml
+  - https://raw.githubusercontent.com/ctrox/csi-s3/v1.2.0-rc.2/deploy/kubernetes/provisioner.yaml
+  - https://raw.githubusercontent.com/ctrox/csi-s3/v1.2.0-rc.2/deploy/kubernetes/csi-s3.yaml
+  - https://raw.githubusercontent.com/ctrox/csi-s3/v1.2.0-rc.2/deploy/kubernetes/examples/storageclass.yaml
+commonLabels:
+    app.kubernetes.io/part-of: csi-s3
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: kustomize
+
+# patch to support kubernetes v1.22+
+# https://github.com/ctrox/csi-s3/pull/70/files
+patchesJson6902:
+  - target:
+      kind: ClusterRole
+      name: external-attacher-runner
+      version: rbac.authorization.k8s.io/v1
+    patch: |-
+      - op: add
+        path: /rules
+        value:
+          apiGroups: ["storage.k8s.io"]
+          resources: ["volumeattachments/status"]
+          verbs: ["patch"]
+images:
+  - name: quay.io/k8scsi/csi-attacher
+    newTag: v3.1.0

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -8,7 +8,9 @@ resources:
   # Nginx ingress controller
   - https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.3.0/deploy/static/provider/cloud/deploy.yaml
   # Media Streaming Service
-  - media
+  - ./media
+  # S3 CSI - Persistent Volume Provisioner
+  - ./csi-s3
 
 helmCharts:
   # OAuth2 Proxy: authentication

--- a/k8s/base/media/kustomization.yaml
+++ b/k8s/base/media/kustomization.yaml
@@ -19,11 +19,13 @@ helmCharts:
     valuesInline:
       # cache jellyfin in worker node specific directory
       persistence:
+        config:
+          enabled: true
+          size: 1Gi
         cache:
           enabled: true
           type: emptyDir
           size: 2Gi
-          accessMode: ReadWriteOnce
 
 # patch jellyfin deployment to mount media downloaded by rtorrent
 patches:

--- a/k8s/base/media/kustomization.yaml
+++ b/k8s/base/media/kustomization.yaml
@@ -25,7 +25,7 @@ helmCharts:
         cache:
           enabled: true
           type: emptyDir
-          size: 2Gi
+          size: 10Gi
 # patch jellyfin deployment to mount media downloaded by rtorrent
 patches:
   - patch-pvc.yaml

--- a/k8s/base/media/kustomization.yaml
+++ b/k8s/base/media/kustomization.yaml
@@ -26,7 +26,6 @@ helmCharts:
           enabled: true
           type: emptyDir
           size: 2Gi
-
 # patch jellyfin deployment to mount media downloaded by rtorrent
 patches:
   - patch-pvc.yaml

--- a/k8s/base/media/rtorrent-flood/deployment.yaml
+++ b/k8s/base/media/rtorrent-flood/deployment.yaml
@@ -20,7 +20,7 @@ spec:
             - name: FLOOD_OPTION_PORT
               value: "3000"
             - name: FLOOD_OPTION_ALLOWEDPATH
-              value: "/cache,/data"
+              value: "/cache/tv,/cache/movies,/data/tv,/data/movies"
             # authentication delegated to ingress upstream
             - name: FLOOD_OPTION_AUTH
               value: "none"

--- a/k8s/base/media/rtorrent-flood/deployment.yaml
+++ b/k8s/base/media/rtorrent-flood/deployment.yaml
@@ -20,7 +20,7 @@ spec:
             - name: FLOOD_OPTION_PORT
               value: "3000"
             - name: FLOOD_OPTION_ALLOWEDPATH
-              value: "/cache/tv,/cache/movies,/data/tv,/data/movies"
+              value: "/cache/tv,/cache/movies,/media/tv,/media/movies"
             # authentication delegated to ingress upstream
             - name: FLOOD_OPTION_AUTH
               value: "none"
@@ -38,8 +38,8 @@ spec:
           volumeMounts:
             - mountPath: /config
               name: config
-            - mountPath: /data
-              name: data
+            - mountPath: /media
+              name: media
             - mountPath: /cache
               name: cache
           readinessProbe:
@@ -53,7 +53,7 @@ spec:
         - name: config
           configMap:
             name: rtorrent-config
-        - name: data
+        - name: media
           persistentVolumeClaim:
             claimName: media-data
         - name: cache

--- a/k8s/base/media/rtorrent-flood/deployment.yaml
+++ b/k8s/base/media/rtorrent-flood/deployment.yaml
@@ -20,7 +20,7 @@ spec:
             - name: FLOOD_OPTION_PORT
               value: "3000"
             - name: FLOOD_OPTION_ALLOWEDPATH
-              value: "/data"
+              value: "/cache,/data"
             # authentication delegated to ingress upstream
             - name: FLOOD_OPTION_AUTH
               value: "none"
@@ -40,6 +40,8 @@ spec:
               name: config
             - mountPath: /data
               name: data
+            - mountPath: /cache
+              name: cache
           readinessProbe:
             failureThreshold: 3
             initialDelaySeconds: 0
@@ -54,5 +56,7 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: media-data
+        - name: cache
+          emptyDir: {}
       securityContext:
         fsGroup: 1001

--- a/k8s/base/media/rtorrent-flood/kustomization.yaml
+++ b/k8s/base/media/rtorrent-flood/kustomization.yaml
@@ -12,6 +12,7 @@ configMapGenerator:
   - name: rtorrent-config
     files:
       - rtorrent.rc
+      - move_completed.sh
 namePrefix: media-
 commonLabels:
     app.kubernetes.io/name: rtorrent-flood

--- a/k8s/base/media/rtorrent-flood/move_completed.sh
+++ b/k8s/base/media/rtorrent-flood/move_completed.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+#
+# Nimbus
+# Media Streaming Service
+# Move Completed Script
+#
+
+set -e -o pipefail
+
+# Usage: move_completed.sh <DOWNLOAD> <SRCDIR> <DESTDIR>
+# Move the complete download the the given path to the given destination dir.
+#
+# Maintains the relative path of the download with the given source dir in the
+# destination dir when moving files. Echos the path of the moved download once moved.
+#
+# Arguments:
+#   <DOWNLOAD>    Absolute path to the downloads to move located within <SRCDIR>.
+#   <SRCDIR>      Absolute path to source directory that contains the downloaded files.
+#   <DESTDIR>     Absolute path to the destination directory to move the downloaded files to.
+#
+
+# check no. of args
+if [[ $# -ne 3 ]]; then
+  echo "move_completed.sh: Expected 3 arguments" >&2
+  exit 1
+fi
+
+# parse args: remove trailing slashes from dirs
+DOWNLOAD="$1"
+SRCDIR=$(printf "$2" | sed -e "s:/$::")
+DESTDIR=$(printf "$3" | sed -e "s:/$::")
+
+# perform move of downloads
+DESTPATH=$(printf "$DOWNLOAD" | sed -e "s:$SRCDIR:$DESTDIR:")
+DESTDIR=$(dirname "$DESTPATH")
+mkdir -p "$DESTPATH"
+mv -f "$DOWNLOAD" "$DESTPATH"
+
+# echo moved path
+if [[ -d ]]; then
+  echo "$DESTPATH"
+else
+  echo "$DESTDIR"
+fi

--- a/k8s/base/media/rtorrent-flood/move_completed.sh
+++ b/k8s/base/media/rtorrent-flood/move_completed.sh
@@ -5,13 +5,13 @@
 # Move Completed Script
 #
 
-set -e -o pipefail
+set -ex -o pipefail
 
 # Usage: move_completed.sh <DOWNLOAD> <SRCDIR> <DESTDIR>
 # Move the complete download the the given path to the given destination dir.
 #
 # Maintains the relative path of the download with the given source dir in the
-# destination dir when moving files. Echos the path of the moved download once moved.
+# destination dir when moving files.
 #
 # Arguments:
 #   <DOWNLOAD>    Absolute path to the downloads to move located within <SRCDIR>.
@@ -35,10 +35,3 @@ DESTPATH=$(printf "$DOWNLOAD" | sed -e "s:$SRCDIR:$DESTDIR:")
 DESTDIR=$(dirname "$DESTPATH")
 mkdir -p "$DESTPATH"
 mv -f "$DOWNLOAD" "$DESTPATH"
-
-# echo moved path
-if [[ -d ]]; then
-  echo "$DESTPATH"
-else
-  echo "$DESTDIR"
-fi

--- a/k8s/base/media/rtorrent-flood/rtorrent.rc
+++ b/k8s/base/media/rtorrent-flood/rtorrent.rc
@@ -15,7 +15,7 @@
 
 ## Instance layout (base paths)
 method.insert = cfg.basedir,  private|const|string, (cat,"/home/download/")
-method.insert = cfg.destdir,  private|const|string, (cat,"/data/")
+method.insert = cfg.destdir,  private|const|string, (cat,"/media/")
 method.insert = cfg.download, private|const|string, (cat,"/cache/")
 method.insert = cfg.session,  private|const|string, (cat,(cfg.basedir),"session/")
 method.insert = cfg.logs,     private|const|string, (cat,(cfg.basedir),"log/")

--- a/k8s/base/media/rtorrent-flood/rtorrent.rc
+++ b/k8s/base/media/rtorrent-flood/rtorrent.rc
@@ -19,7 +19,6 @@ method.insert = cfg.destdir,  private|const|string, (cat,"/data/")
 method.insert = cfg.download, private|const|string, (cat,"/cache/")
 method.insert = cfg.session,  private|const|string, (cat,(cfg.basedir),"session/")
 method.insert = cfg.logs,     private|const|string, (cat,(cfg.basedir),"log/")
-method.insert = cfg.watch,    private|const|string, (cat,(cfg.basedir),"watch/")
 method.insert = cfg.logfile,  private|const|string, (cat,(cfg.logs),"rtorrent-",(system.time),".log")
 
 
@@ -31,10 +30,7 @@ execute.throw = sh, -c, (cat,\
     "\"",(cfg.destdir),"/movies\" ",\
     "\"",(cfg.destdir),"/tv\" ",\
     "\"",(cfg.logs),"\" ",\
-    "\"",(cfg.session),"\" ",\
-    "\"",(cfg.watch),"/load\" ",\
-    "\"",(cfg.watch),"/start\" ")
-
+    "\"",(cfg.session),"\" ")
 
 ## Listening port for incoming peer traffic (fixed; you can also randomize it)
 network.port_random.set = no
@@ -104,15 +100,9 @@ method.insert = d.data_path, simple,\
         (cat, (d.directory), /),\
         (cat, (d.directory), /, (d.name))"
 method.insert = d.session_file, simple, "cat=(session.path), (d.hash), .torrent"
+# TODO(mrzzy): refactor this into a bash script.
 method.insert = d.move_to_complete, simple, "d.directory.set=$argument.1=; execute=mkdir,-p,$argument.1=; execute=mv,-u,$argument.0=,$argument.1=; d.save_full_session="
 method.set_key = event.download.finished,move_complete,"d.move_to_complete=$d.data_path=,$cfg.destdir="
-
-
-## Watch directories (add more as you like, but use unique schedule names)
-## Add torrent
-schedule2 = watch_load, 11, 10, ((load.verbose, (cat, (cfg.watch), "load/*.torrent")))
-## Add & download straight away
-schedule2 = watch_start, 10, 10, ((load.start_verbose, (cat, (cfg.watch), "start/*.torrent")))
 
 
 ## Run the rTorrent process as a daemon in the background

--- a/k8s/base/media/rtorrent-flood/rtorrent.rc
+++ b/k8s/base/media/rtorrent-flood/rtorrent.rc
@@ -15,11 +15,12 @@
 
 ## Instance layout (base paths)
 method.insert = cfg.basedir,  private|const|string, (cat,"/home/download/")
-method.insert = cfg.download, private|const|string, (cat,"/data/")
+method.insert = cfg.destdir,  private|const|string, (cat,"/data/")
+method.insert = cfg.download, private|const|string, (cat,"/cache/")
+method.insert = cfg.session,  private|const|string, (cat,(cfg.basedir),"session/")
 method.insert = cfg.logs,     private|const|string, (cat,(cfg.basedir),"log/")
-method.insert = cfg.logfile,  private|const|string, (cat,(cfg.logs),"rtorrent-",(system.time),".log")
-method.insert = cfg.session,  private|const|string, (cat,(cfg.basedir),"/session/")
 method.insert = cfg.watch,    private|const|string, (cat,(cfg.basedir),"watch/")
+method.insert = cfg.logfile,  private|const|string, (cat,(cfg.logs),"rtorrent-",(system.time),".log")
 
 
 ## Create instance directories
@@ -99,6 +100,8 @@ method.insert = d.data_path, simple,\
         (cat, (d.directory), /),\
         (cat, (d.directory), /, (d.name))"
 method.insert = d.session_file, simple, "cat=(session.path), (d.hash), .torrent"
+method.insert = d.move_to_complete, simple, "d.directory.set=$argument.1=; execute=mkdir,-p,$argument.1=; execute=mv,-u,$argument.0=,$argument.1=; d.save_full_session="
+method.set_key = event.download.finished,move_complete,"d.move_to_complete=$d.data_path=,$cfg.destdir="
 
 
 ## Watch directories (add more as you like, but use unique schedule names)
@@ -121,6 +124,6 @@ execute.nothrow = chmod,770,(cat,(session.path),rpc.socket)
 print = (cat, "Logging to ", (cfg.logfile))
 log.open_file = "log", (cfg.logfile)
 log.add_output = "info", "log"
-#log.add_output = "tracker_debug", "log"
+log.add_output = "tracker_debug", "log"
 
 ### END of rtorrent.rc ###

--- a/k8s/base/media/rtorrent-flood/rtorrent.rc
+++ b/k8s/base/media/rtorrent-flood/rtorrent.rc
@@ -100,10 +100,10 @@ method.insert = d.data_path, simple,\
         (cat, (d.directory), /),\
         (cat, (d.directory), /, (d.name))"
 method.insert = d.session_file, simple, "cat=(session.path), (d.hash), .torrent"
-# TODO(mrzzy): refactor this into a bash script.
-method.insert = d.move_to_complete, simple, "d.directory.set=$argument.1=; execute=mkdir,-p,$argument.1=; execute=mv,-u,$argument.0=,$argument.1=; d.save_full_session="
-method.set_key = event.download.finished,move_complete,"d.move_to_complete=$d.data_path=,$cfg.destdir="
 
+# execute move to complete script once download is complete
+method.insert = d.move_to_complete, simple, "execute=sh, /config/move_completed.sh, $argument.0=, $argument.1=, $argument.2="
+method.set_key = event.download.finished,move_complete,"d.move_to_complete=$d.data_path=,$cfg.download=,$cfg.destdir=; d.erase="
 
 ## Run the rTorrent process as a daemon in the background
 ## (and control via XMLRPC sockets)

--- a/k8s/base/media/rtorrent-flood/rtorrent.rc
+++ b/k8s/base/media/rtorrent-flood/rtorrent.rc
@@ -26,6 +26,10 @@ method.insert = cfg.logfile,  private|const|string, (cat,(cfg.logs),"rtorrent-",
 ## Create instance directories
 execute.throw = sh, -c, (cat,\
     "mkdir -p \"",(cfg.download),"\" ",\
+    "\"",(cfg.download),"/movies\" ",\
+    "\"",(cfg.download),"/tv\" ",\
+    "\"",(cfg.destdir),"/movies\" ",\
+    "\"",(cfg.destdir),"/tv\" ",\
     "\"",(cfg.logs),"\" ",\
     "\"",(cfg.session),"\" ",\
     "\"",(cfg.watch),"/load\" ",\

--- a/k8s/lke/media/pvc.yaml
+++ b/k8s/lke/media/pvc.yaml
@@ -9,7 +9,5 @@ kind: PersistentVolumeClaim
 metadata:
   name: media-data
 spec:
-  # default linode storage class retains the volume even after the pvc is deleted
-  # change the storage class to ensure volume gets deleted when pvc is deleted
-  # https://www.linode.com/docs/guides/deploy-volumes-with-the-linode-block-storage-csi-driver/
-  storageClassName: linode-block-storage
+  # store media files in cheaper Backblaze B2 cloud object storage
+  storageClassName: csi-s3

--- a/terraform/linode.tf
+++ b/terraform/linode.tf
@@ -6,6 +6,8 @@
 locals {
   # Linode deploy region
   linode_region = "ap-south" # singapore
+  # Backblaze B2 S3-compatible regional endpoint
+  b2_endpoint = "s3.us-west-001.backblazeb2.com"
 }
 
 # Linode Cloud
@@ -27,6 +29,13 @@ module "k8s" {
   }
   tls_keys = {
     "${local.domain_slug}-tls" = module.tls_cert.private_key,
+  }
+
+  # Configure S3 CSI to provision volumes backed by B2 buckets
+  s3_csi = {
+    access_key    = b2_application_key.k8s_csi.application_key    #gitleaks:allow
+    access_key_id = b2_application_key.k8s_csi.application_key_id #gitleaks:allow
+    s3_endpoint   = local.b2_endpoint
   }
 }
 

--- a/terraform/linode.tf
+++ b/terraform/linode.tf
@@ -7,7 +7,7 @@ locals {
   # Linode deploy region
   linode_region = "ap-south" # singapore
   # Backblaze B2 S3-compatible regional endpoint
-  b2_endpoint = "https://s3.us-west-001.backblazeb2.com"
+  b2_endpoint = "https://s3.us-west-004.backblazeb2.com"
 }
 
 # Linode Cloud

--- a/terraform/linode.tf
+++ b/terraform/linode.tf
@@ -7,7 +7,7 @@ locals {
   # Linode deploy region
   linode_region = "ap-south" # singapore
   # Backblaze B2 S3-compatible regional endpoint
-  b2_endpoint = "s3.us-west-001.backblazeb2.com"
+  b2_endpoint = "https://s3.us-west-001.backblazeb2.com"
 }
 
 # Linode Cloud

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -64,3 +64,9 @@ resource "b2_bucket" "volt_bkp" {
     mode      = "SSE-B2"
   }
 }
+
+# store media files for media streaming service
+resource "b2_bucket" "media" {
+  bucket_name = "${local.domain_slug}-media"
+  bucket_type = "allPrivate"
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -53,7 +53,6 @@ module "tls_cert" {
 
 # Backblaze B2 Cloud Storage provider
 provider "b2" {}
-
 # off-site backup location for volt (laptop)
 resource "b2_bucket" "volt_bkp" {
   bucket_name = "${local.domain_slug}-volt-backup"
@@ -64,9 +63,16 @@ resource "b2_bucket" "volt_bkp" {
     mode      = "SSE-B2"
   }
 }
-
-# store media files for media streaming service
-resource "b2_bucket" "media" {
-  bucket_name = "${local.domain_slug}-media"
-  bucket_type = "allPrivate"
+# App Key to auth S3 CSI for provisioning B2 Bucket backed K8s Persistent Volumes
+resource "b2_application_key" "k8s_csi" {
+  key_name = "k8s-csi"
+  capabilities = [
+    "readBuckets",
+    "writeBuckets",
+    "listFiles",
+    "readFiles",
+    "shareFiles",
+    "writeFiles",
+    "deleteFiles",
+  ]
 }

--- a/terraform/modules/linode/k8s/.terraform.lock.hcl
+++ b/terraform/modules/linode/k8s/.terraform.lock.hcl
@@ -1,0 +1,44 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version     = "2.12.1"
+  constraints = "2.12.1"
+  hashes = [
+    "h1:6ZgqegUao9WcfVzYg7taxCQOQldTmMVw0HqjG5S46OY=",
+    "zh:1ecb2adff52754fb4680c7cfe6143d1d8c264b00bb0c44f07f5583b1c7f978b8",
+    "zh:1fbd155088cd5818ad5874e4d59ccf1801e4e1961ac0711442b963315f1967ab",
+    "zh:29e927c7c8f112ee0e8ab70e71b498f2f2ae6f47df1a14e6fd0fdb6f14b57c00",
+    "zh:42c2f421da6b5b7c997e42aa04ca1457fceb13dd66099a057057a0812b680836",
+    "zh:522a7bccd5cd7acbb4ec3ef077d47f4888df7e59ff9f3d598b717ad3ee4fe9c9",
+    "zh:b45d8dc5dcbc5e30ae570d0c2e198505f47d09098dfd5f004871be8262e6ec1e",
+    "zh:c3ea0943f2050001c7d6a7115b9b990f148b082ebfc4ff3c2ff3463a8affcc4a",
+    "zh:f111833a64e06659d2e21864de39b7b7dec462615294d02f04c777956742a930",
+    "zh:f182dba5707b90b0952d5984c23f7a2da3baa62b4d71e78df7759f16cc88d957",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f76655a68680887daceabd947b2f68e2103f5bbec49a2bc29530f82ab8e3bca3",
+    "zh:fadb77352caa570bd3259dfb59c31db614d55bc96df0ff15a3c0cd2e685678b9",
+  ]
+}
+
+provider "registry.terraform.io/linode/linode" {
+  version     = "1.28.1"
+  constraints = ">= 1.28.0, < 1.29.0"
+  hashes = [
+    "h1:eRVL+bDk2k6Y7Ig+VyZUU1jMdS9eiepK4PV55pMbvoQ=",
+    "zh:1a3819dd7e6408edebb855037acba53e1ef35e9e37ac69983b028332f096965b",
+    "zh:2ca6b21ff5d1afe0482517e2a4330b0f358820c03a40e1ff84b7a95b84c6bf11",
+    "zh:6212deb0ddb95214c8ed95867c5aca2f3db57192bab6a20ff925552ad813e860",
+    "zh:66f686088406e5006e59efc9858d8ac08ad1456ee8de5e4ea0ede7f50018cf93",
+    "zh:8f5335a71fb5bb876f6c6c8523abfe4d369e4d831d8e2501c7bc695a4f35f873",
+    "zh:955c4372648aa1415f8d3b14ddfa0b0695210d211aa29e4d665ee45721763095",
+    "zh:b798f5fefd0c71f8bc411ea9af3a58af9d80c78cd4d2e88e6bd07b68c62ddde3",
+    "zh:bc08690d655ba74f72bdc8a9bf45ac45e97b334b9b08713a9b85dbb4e6e898e7",
+    "zh:c344e93349d79c5dc6ced60da688b5d5ba14c2e3636aba70d509128e76e155fe",
+    "zh:d249b154b5d87741880da790bbdf38ed1fbaa9b7cf4699d3496f4c475a3e68ae",
+    "zh:e03210f86937adfff080dba4b2f84dad0e1f7b1dbee98df805c2c8d9fa4dd1e9",
+    "zh:e84d6438ba1db954ebd1e66e0d21fc7097eb63253d53b35ba9c0db571d8684ea",
+    "zh:e9bea27bd515b86973222d1d9c2bb8108df9c49003c8b2a14b91dbcc70cd5f80",
+    "zh:facb3933992a6eb3a421d2544d5528e46619f7d0efef7144a142b809f877101f",
+  ]
+}

--- a/terraform/modules/linode/k8s/main.tf
+++ b/terraform/modules/linode/k8s/main.tf
@@ -78,6 +78,7 @@ resource "kubernetes_secret" "s3_csi" {
     "endpoint"        = var.s3_csi.s3_endpoint,
     "accessKeyID"     = var.s3_csi.access_key_id,
     "secretAccessKey" = var.s3_csi.access_key,
+    # as we are not using Amazon S3, the region field is unused
     "region"          = ""
   }
 }

--- a/terraform/modules/linode/k8s/main.tf
+++ b/terraform/modules/linode/k8s/main.tf
@@ -49,7 +49,8 @@ data "kubernetes_service" "ingress" {
   }
 }
 
-# TLS K8s secrets
+# K8s Secrets
+# tls
 resource "kubernetes_secret" "tls" {
   for_each = var.tls_certs
 
@@ -64,5 +65,19 @@ resource "kubernetes_secret" "tls" {
   data = {
     "tls.crt" = each.value["cert"],
     "tls.key" = var.tls_keys[each.key],
+  }
+}
+# S3 CSI credentials
+resource "kubernetes_secret" "s3_csi" {
+  metadata {
+    name      = "csi-s3-secret"
+    namespace = "kube-system"
+  }
+
+  data = {
+    "endpoint"        = var.s3_csi["endpoint"],
+    "accessKeyID"     = var.s3_csi["access_key_id"],
+    "secretAccessKey" = var.s3_csi["access_key"],
+    "region"          = ""
   }
 }

--- a/terraform/modules/linode/k8s/main.tf
+++ b/terraform/modules/linode/k8s/main.tf
@@ -75,9 +75,9 @@ resource "kubernetes_secret" "s3_csi" {
   }
 
   data = {
-    "endpoint"        = var.s3_csi["endpoint"],
-    "accessKeyID"     = var.s3_csi["access_key_id"],
-    "secretAccessKey" = var.s3_csi["access_key"],
+    "endpoint"        = var.s3_csi.s3_endpoint,
+    "accessKeyID"     = var.s3_csi.access_key_id,
+    "secretAccessKey" = var.s3_csi.access_key,
     "region"          = ""
   }
 }

--- a/terraform/modules/linode/k8s/main.tf
+++ b/terraform/modules/linode/k8s/main.tf
@@ -50,7 +50,7 @@ data "kubernetes_service" "ingress" {
 }
 
 # K8s Secrets
-# tls
+# TLS
 resource "kubernetes_secret" "tls" {
   for_each = var.tls_certs
 

--- a/terraform/modules/linode/k8s/variables.tf
+++ b/terraform/modules/linode/k8s/variables.tf
@@ -47,3 +47,19 @@ variable "tls_keys" {
     and the value should be a PEM encoded TLS private key.
   EOF
 }
+
+variable "s3_csi" {
+  type = object({
+    s3_endpoint   = string,
+    access_key_id = string,
+    access_key    = string,
+  })
+  sensitive   = true
+  default     = null
+  description = <<EOF
+    Credentials to pass to S3 CSI to provision Persistent Volumes on S3-compatible storage.
+
+    Passes the given config & credentials to the S3 CSI by applying a 'csi-s3-secret'
+    K8s Secret on the 'kube-system' namespace in the K8s Cluster.
+  EOF
+}


### PR DESCRIPTION
# Purpose
Backblaze B2 storage is cheaper than storing flies on Linode Volumes.
Closes: #48 

# Contents
Switch to Backblaze B2 Bucket for Media File Storage:
- add support for k8s Persistent Volumes backed by B2 Buckets with csi-s3
- switch `media-data` Persistent Volume claim to use B2 Bucket storage.
- refactor rtorrent-flood to download to temporary cache volume before moving the media file into CSI S3.

Refactor: remove rtorrent's unused "watch for torrent files" functionality.