### PR TITLE
refactor(terraform): Reduce cost of WARP VM Proxy by Disable GAE App

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ tag?
 # vim project files
 /.vim/
 
+# dotenv
+.env
+
 ### jsonnet
 # ignore jsonnet-bundler's vendor dir
 vendor/

--- a/terraform/gcp.tf
+++ b/terraform/gcp.tf
@@ -116,13 +116,17 @@ module "warp_vm" {
   ssh_public_key = local.ssh_public_key
 }
 # proxy on Google App Engine to provide access to WARP VM behind a corporate firewall.
+resource "google_app_engine_application" "warp_proxy" {
+  project     = local.gcp_project_id
+  location_id = local.gcp_region
+  # only enable proxy if warp VM is also enabled
+  serving_status = var.has_warp_vm ? "SERVING" : "USER_DISABLED"
+}
 resource "google_app_engine_flexible_app_version" "warp_proxy_v1" {
   version_id                = "v1"
   runtime                   = "custom"
   service                   = "default"
   delete_service_on_destroy = true
-  # only deploy proxy if warp VM is also enabled
-  serving_status = var.has_warp_vm ? "SERVING" : "STOPPED"
 
   deployment {
     container {


### PR DESCRIPTION
# Purpose
Currently, Terraform attempts to stop the WARP VM Proxy GAE Service by setting it to stopped in order to disable the Proxy when not used to cut costs:
https://github.com/mrzzy/nimbus/blob/78b835f7281923f2797cd2fbf2d4865b0254899c/terraform/gcp.tf#L125

However, upon futher inspection, the GAE Service still had instances running dispite being marked as `STOPPED`, thereby incuring billing even when WARP VM was not deployed. 

This could be due to GAE asserting that the `default` service be running at all times to serve requests.

# Contents
Reduce cost of WARP VM Proxy by Disable GAE App:
- by disabling the GAE Application entirely instances held by the WARP VM Proxy will be terminated as originally intented.
