### PR TITLE
feat(k8s): Deploy Promtheus, Grafana & Loki for Monitoring / Logging

### DIFF
--- a/.github/workflows/apply-terraform.yaml
+++ b/.github/workflows/apply-terraform.yaml
@@ -77,8 +77,6 @@ jobs:
           TF_VAR_warp_allow_ports: "${{ github.event.inputs.warp_vm_allow_ports }}"
           TF_VAR_warp_http_terminal: "${{ github.event.inputs.warp_vm_http_term }}"
           TF_VAR_warp_allow_ip: "${{ github.event.inputs.warp_vm_allow_ip }}"
-          # use LetsEncrypt's production server to issue trusted TLS certificates
-          TF_VAR_acme_server_url: "https://acme-v02.api.letsencrypt.org/directory"
         run: >
           terraform apply
           -auto-approve=true

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -5,17 +5,20 @@
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 resources:
-  # Nginx ingress controller
+  # Nginx Ingress Controller
+  # Ingress: Nginx
   - https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.3.0/deploy/static/provider/cloud/deploy.yaml
   # K8s Metrics Server
   - https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.6.1/components.yaml
-  # Media Streaming Service
+  # Media Server: Jellyfin & Rtorrent
   - ./media
-  # CSI Rclone - S3-like cloud storage backed Persistent Volumes
+  # CSI Rclone: S3-like cloud storage backed Persistent Volumes
   - ./csi-rclone
+  # Monitoring: Prometheus, Grafana
+  - ./monitoring
 
 helmCharts:
-  # OAuth2 Proxy: authentication
+  # Authentication: OAuth2 Proxy
   - name: oauth2-proxy
     version: 6.2.7
     repo: https://oauth2-proxy.github.io/manifests

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -7,6 +7,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 resources:
   # Nginx ingress controller
   - https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.3.0/deploy/static/provider/cloud/deploy.yaml
+  # K8s Metrics Server
+  - https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.6.1/components.yaml
   # Media Streaming Service
   - ./media
   # CSI Rclone - S3-like cloud storage backed Persistent Volumes

--- a/k8s/base/monitoring/kustomization.yaml
+++ b/k8s/base/monitoring/kustomization.yaml
@@ -44,7 +44,7 @@ helmCharts:
           type: s3
           s3:
             endpoint: '${S3_ENDPOINT}'
-            accessKeyID: '${S3_ACCESS_KEY_ID}'
+            accessKeyId: '${S3_ACCESS_KEY_ID}'
             secretAccessKey: '${S3_SECRET_ACCESS_KEY}'
           bucketNames:
             ruler: '${LOKI_LOG_BUCKET}'

--- a/k8s/base/monitoring/kustomization.yaml
+++ b/k8s/base/monitoring/kustomization.yaml
@@ -61,3 +61,9 @@ helmCharts:
       monitoring:
         serviceMonitor:
           enabled: true
+  # Log Forwarder: Promtail
+  - namespace: monitoring
+    releaseName: logs
+    name: promtail
+    version: 6.4.0
+    repo: https://grafana.github.io/helm-charts

--- a/k8s/base/monitoring/kustomization.yaml
+++ b/k8s/base/monitoring/kustomization.yaml
@@ -37,6 +37,16 @@ helmCharts:
       # use s3 as a data store to persist logs ingested into loki
       # pass s3 credentials to loki by populating environment with credentials &
       # configuring loki to load them from the environment
+        storage:
+          type: s3
+          s3:
+            endpoint: '${S3_ENDPOINT}'
+            accessKeyID: '${S3_ACCESS_KEY_ID}'
+            secretAccessKey: '${S3_SECRET_ACCESS_KEY}'
+          bucketNames:
+            ruler: '${LOKI_LOG_BUCKET}'
+            chunks: '${LOKI_LOG_BUCKET}'
+            admin: '${LOKI_LOG_BUCKET}'
       read:
         extraArgs:
           - "-config.expand-env=true"
@@ -47,16 +57,7 @@ helmCharts:
           - "-config.expand-env=true"
         extraEnvFrom:
           - secret: loki-s3-credentials
-      storage:
-        type: s3
-        s3:
-          endpoint: '${S3_ENDPOINT}'
-          accessKeyID: '${S3_ACCESS_KEY_ID}'
-          secretAccessKey: '${S3_SECRET_ACCESS_KEY}'
-        bucketNames:
-          ruler: '${LOKI_LOG_BUCKET}'
-          chunks: '${LOKI_LOG_BUCKET}'
-          admin: '${LOKI_LOG_BUCKET}'
       # monitor Loki with Prometheus
-      serviceMonitor:
-        enabled: true
+      monitoring:
+        serviceMonitor:
+          enabled: true

--- a/k8s/base/monitoring/kustomization.yaml
+++ b/k8s/base/monitoring/kustomization.yaml
@@ -78,3 +78,7 @@ helmCharts:
       # monitor promtail's metrics with Prometheus
       serviceMonitor:
         enabled: true
+
+# corce all resources to deploy in monitoring namespace
+# needed as Loki's helm chart does not respect the namespace set at helmCharts level
+namespace: monitoring

--- a/k8s/base/monitoring/kustomization.yaml
+++ b/k8s/base/monitoring/kustomization.yaml
@@ -1,0 +1,16 @@
+#
+# Nimbus
+# K8s Deployment
+# Monitoring
+#
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+resources:
+  - namespace.yaml
+helmCharts:
+  # Kube Prometheus: Prometheus, Grafana & Prometheus Operator
+  - name: kube-prometheus-stack
+    version: 40.1.0
+    repo: https://prometheus-community.github.io/helm-charts
+    releaseName: monitor
+    namespace: monitoring

--- a/k8s/base/monitoring/kustomization.yaml
+++ b/k8s/base/monitoring/kustomization.yaml
@@ -7,6 +7,15 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 resources:
   - namespace.yaml
+  # NOTE: Prometheus Operator CRs should be upgraded in tandem withn the kube-prometheus helm chart
+  - https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.59.1/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
+  - https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.59.1/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+  - https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.59.1/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
+  - https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.59.1/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
+  - https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.59.1/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+  - https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.59.1/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
+  - https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.59.1/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+  - https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.59.1/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
 helmCharts:
   # Kube Prometheus: Prometheus, Grafana & Prometheus Operator
   - name: kube-prometheus-stack

--- a/k8s/base/monitoring/kustomization.yaml
+++ b/k8s/base/monitoring/kustomization.yaml
@@ -7,7 +7,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 resources:
   - namespace.yaml
-  # NOTE: Prometheus Operator CRs should be upgraded in tandem withn the kube-prometheus helm chart
+  # NOTE: Prometheus Operator CRDs should be upgraded in tandem withn the kube-prometheus helm chart
   - https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.59.1/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
   - https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.59.1/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
   - https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.59.1/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
@@ -17,9 +17,46 @@ resources:
   - https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.59.1/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
   - https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.59.1/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
 helmCharts:
-  # Kube Prometheus: Prometheus, Grafana & Prometheus Operator
-  - name: kube-prometheus-stack
+  # Monitoring: Prometheus, Grafana & Prometheus Operator
+  - namespace: monitoring
+    releaseName: monitor
+    name: kube-prometheus-stack
     version: 40.1.0
     repo: https://prometheus-community.github.io/helm-charts
-    releaseName: monitor
-    namespace: monitoring
+  # Logging: Loki
+  - namespace: monitoring
+    releaseName: log
+    name: loki
+    version: 3.1.0
+    repo: https://grafana.github.io/helm-charts
+    valuesInline:
+      loki:
+        auth_enabled: false
+        commonConfig:
+          replication_factor: 1
+      # use s3 as a data store to persist logs ingested into loki
+      # pass s3 credentials to loki by populating environment with credentials &
+      # configuring loki to load them from the environment
+      read:
+        extraArgs:
+          - "-config.expand-env=true"
+        extraEnvFrom:
+          - secret: loki-s3-credentials
+      write:
+        extraArgs:
+          - "-config.expand-env=true"
+        extraEnvFrom:
+          - secret: loki-s3-credentials
+      storage:
+        type: s3
+        s3:
+          endpoint: '${S3_ENDPOINT}'
+          accessKeyID: '${S3_ACCESS_KEY_ID}'
+          secretAccessKey: '${S3_SECRET_ACCESS_KEY}'
+        bucketNames:
+          ruler: '${LOKI_LOG_BUCKET}'
+          chunks: '${LOKI_LOG_BUCKET}'
+          admin: '${LOKI_LOG_BUCKET}'
+      # monitor Loki with Prometheus
+      serviceMonitor:
+        enabled: true

--- a/k8s/base/monitoring/kustomization.yaml
+++ b/k8s/base/monitoring/kustomization.yaml
@@ -32,6 +32,11 @@ helmCharts:
     valuesInline:
       loki:
         auth_enabled: false
+        # loki by default requires a quorum of 2/3 writes for a log entry to be ingested
+        # lower replication_factor to 1 in order to allow the no. of write (ingester)
+        # replicas to be lowered.
+        commonConfig:
+          replication_factor: 1
       # use s3 as a data store to persist logs ingested into loki
       # pass s3 credentials to loki by populating environment with credentials &
       # configuring loki to load them from the environment
@@ -46,12 +51,14 @@ helmCharts:
             chunks: '${LOKI_LOG_BUCKET}'
             admin: '${LOKI_LOG_BUCKET}'
       read:
+        replicas: 1
         extraArgs:
           - "-config.expand-env=true"
         extraEnvFrom:
           - secretRef:
               name: loki-s3-credentials
       write:
+        replicas: 1
         extraArgs:
           - "-config.expand-env=true"
         extraEnvFrom:

--- a/k8s/base/monitoring/kustomization.yaml
+++ b/k8s/base/monitoring/kustomization.yaml
@@ -32,8 +32,6 @@ helmCharts:
     valuesInline:
       loki:
         auth_enabled: false
-        commonConfig:
-          replication_factor: 1
       # use s3 as a data store to persist logs ingested into loki
       # pass s3 credentials to loki by populating environment with credentials &
       # configuring loki to load them from the environment
@@ -57,13 +55,26 @@ helmCharts:
           - "-config.expand-env=true"
         extraEnvFrom:
           - secret: loki-s3-credentials
-      # monitor Loki with Prometheus
       monitoring:
+        # monitor Loki's metrics with Prometheus
         serviceMonitor:
           enabled: true
-  # Log Forwarder: Promtail
+        # disable self monitoring as its too heavy for our use case:
+        # it needs grafana agent operator to deployed as well.
+        selfMonitoring:
+          enabled: false
+          grafanaAgent:
+            installOperator: false
+        # disable grafana dashboards as it relies on selfMonitoring
+        dashboards:
+          enabled: false
+  # Log Forwarder: promtail
   - namespace: monitoring
     releaseName: logs
     name: promtail
     version: 6.4.0
     repo: https://grafana.github.io/helm-charts
+    valuesInline:
+      # monitor promtail's metrics with Prometheus
+      serviceMonitor:
+        enabled: true

--- a/k8s/base/monitoring/kustomization.yaml
+++ b/k8s/base/monitoring/kustomization.yaml
@@ -49,12 +49,14 @@ helmCharts:
         extraArgs:
           - "-config.expand-env=true"
         extraEnvFrom:
-          - secret: loki-s3-credentials
+          - secretRef:
+              name: loki-s3-credentials
       write:
         extraArgs:
           - "-config.expand-env=true"
         extraEnvFrom:
-          - secret: loki-s3-credentials
+          - secretRef:
+              name: loki-s3-credentials
       monitoring:
         # monitor Loki's metrics with Prometheus
         serviceMonitor:

--- a/k8s/base/monitoring/namespace.yaml
+++ b/k8s/base/monitoring/namespace.yaml
@@ -1,0 +1,10 @@
+#
+# Nimbus
+# K8s Deployment
+# Monitoring
+#
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring

--- a/k8s/lke/kustomization.yaml
+++ b/k8s/lke/kustomization.yaml
@@ -30,3 +30,17 @@ patches:
   - media/patch-pv.yaml
   - oauth2-proxy/patch-deployment.yaml
   - oauth2-proxy/patch-ingress.yaml
+
+patchesJson6902:
+  # patch Metrics Server to disable TLS when scraping Linode worker's kubelet as
+  # Linode does not configure with the correct TLS certificate.
+  # https://github.com/kubernetes-sigs/metrics-server/issues/1025
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: metrics-server
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/args/-1
+        value: --kubelet-insecure-tls

--- a/renovate.json
+++ b/renovate.json
@@ -10,9 +10,21 @@
   "regexManagers": [
     {
       "fileMatch": "^k8s/.*/kustomization.yaml$",
-      "matchStrings": ["(?<depName>kubernetes\\/ingress-nginx)\\/controller-(?<version>.*)\\/"],
+      "matchStrings": [
+        "(?<depName>kubernetes\\/ingress-nginx)\\/controller-(?<version>.*)\\/"
+      ],
       "datasourceTemplate": "github-releases",
+      "versioningTemplate": "loose",
       "extractVersionTemplate": "^controller-$(?<version>.*)$"
+    },
+    {
+      "fileMatch": "^k8s/.*/kustomization.yaml$",
+      "matchStrings": [
+        "(?<depName>kubenetes-sigs\\/metrics-server)\\/releases\\/download\\/(?<version>.*)\\/"
+      ],
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "loose",
+      "extractVersionTemplate": "^$(?<version>v.*)$"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -6,5 +6,13 @@
   ],
   "reviewers": [
     "mrzzy"
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": "^k8s/.*/kustomization.yaml$",
+      "matchStrings": ["(?<depName>kubernetes\\/ingress-nginx)\\/controller-(?<version>.*)\\/"],
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^controller-$(?<version>.*)$"
+    }
   ]
 }

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -31,12 +31,26 @@ provider "registry.terraform.io/cloudflare/cloudflare" {
     "h1:tjRge01jJMYwayKF0g5+6XZf1Keb+KXr0L4+LTTMyng=",
     "h1:y3uYs2MZtE3MwHLFoeRNWOIB93aGFecYukPcfxcff9k=",
     "h1:yueDmUEuKOe5DYKw1szmXOnrRkeCwckMgzUesrLsYXw=",
+    "zh:190408c7f17a4bcb6eef4faaf3cbcd7bc71ffe2da0bae53bf198267b386e1eca",
+    "zh:2a17671e6d567c488c4b748a318ff3a49ce5a395b2a850ce18327ac110f24ca4",
+    "zh:2d00a73e3baa3c620d10cdc448c04210c11d3dbdfc7b327d225cb9e37c760d65",
+    "zh:328238bb6541b7373ffb499826def6a5105a23f4362d275aea08f4be18a5456b",
+    "zh:360c01f73fb1aae93021957fcd384cda7f675d77918ff29563644d2cced5537c",
+    "zh:4a8a8b81429d25c8480fac90bae06132b0be3d506941b14cbc383ce71a66e7b5",
+    "zh:62991a8f5eab1d30ffdfe2ef440cda200230ca39338df478ef26f1da7ea7b13b",
+    "zh:7c8b54bebd905cdc995a77665f7ea2fe9a416446c78a7630b79c66eb4285ae61",
+    "zh:8ba7d300a3a01d71ff932674b8669ce4c06ca6e6b1ad4bc6814decde0885292c",
+    "zh:95277d0edd3caab4ba47becf6aecbc27df25df6f3a630972efa4626d38fa570f",
+    "zh:cef1d2f45d731e60fca9bf42eafdc4a3e78954882c4d1f26f8e4bf985db854ce",
+    "zh:e9724344b49945fcbb87f336c958c0fbb00fe524c1cb59545417f81a442b43d9",
+    "zh:ed314269d7e343c84433d285f6865191441b706a35ee2083f4d1f454aa33d06f",
+    "zh:feaa86c9f0101ae10eb7491f262ed85e9d7a235763faec6e143a5563747dd4af",
   ]
 }
 
 provider "registry.terraform.io/hashicorp/google" {
   version     = "4.37.0"
-  constraints = "< 4.37.1"
+  constraints = ">= 3.64.0, >= 4.22.0, < 4.37.1, < 5.0.0"
   hashes = [
     "h1:0c18hCPStLBpmhOzIYjSE0feoAqMudmbCm/dFalHO5w=",
     "h1:3T5iRtAy50QsDHUngJpS0o6Udaofe5Pk2YbjQZjoZz4=",
@@ -49,6 +63,18 @@ provider "registry.terraform.io/hashicorp/google" {
     "h1:ofDmneOgJu+vm6a5KRuIAWE1vKQTFhXzTxUx+HvWix8=",
     "h1:pXLQoWh7q5ENdC04CvpOd/5wlo0jtg493ep7+DMFwlk=",
     "h1:yGGYMteAyog//BT0yr98W39F1cm2k2hFJ3mcnObWpZc=",
+    "zh:01ae3e36f33651d2fa38499a13385f7a12df34cd6c5bbe59458f970f9e78a39a",
+    "zh:1c5bd5bb926216db863d1915f1c7c8ef5c4828931d7ac5446b1eec6f226bdd40",
+    "zh:1eac85f93f315a60b04206ada873b762453f126b5757cfc26a9073f2fafbd6a8",
+    "zh:422d7945c5556731d84ea4877a2d029f258e32efc59f4a473edfae0a6a1e925d",
+    "zh:66162f95d14c0db6c6fefb0f513192d840d401779603ee897518e9802748dde9",
+    "zh:679c23db26203be260b602fe88a7e622fca135074ab2746e567d048c07704113",
+    "zh:87404af4b1cad2922af395e229cdf683578c0ac99ccb2a141ada1cd623c850e5",
+    "zh:a8eec14b312b306aead96f880c62613a4000ae8b80e7aeef28054de5a380a7b8",
+    "zh:e367ce43096157cff544b0597383a266c964480c81f3f6d917cfdaccaaa6ee59",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f7bd4c60d7c9f36fadc177fe190ee62836aac38b1cbb6deebc8f60d3a72b5a4b",
+    "zh:fcf20dbf699f784cd04db84960beb5bb887ac5f049856251ec7f664dfacf83b9",
   ]
 }
 

--- a/terraform/gcp.tf
+++ b/terraform/gcp.tf
@@ -145,8 +145,15 @@ resource "google_app_engine_flexible_app_version" "warp_proxy_v1" {
   manual_scaling {
     instances = 1
   }
-}
 
+  lifecycle {
+    # GAE automatically assigns service to the default service account
+    # direct terraform to ignore this change.
+    ignore_changes = [
+      service_account
+    ]
+  }
+}
 
 # GCP: enroll project-wide ssh key for ssh access to VMs
 resource "google_compute_project_metadata_item" "ssh_keys" {

--- a/terraform/gcp.tf
+++ b/terraform/gcp.tf
@@ -147,10 +147,11 @@ resource "google_app_engine_flexible_app_version" "warp_proxy_v1" {
   }
 
   lifecycle {
-    # GAE automatically assigns service to the default service account
-    # direct terraform to ignore this change.
     ignore_changes = [
-      service_account
+      # GAE automatically assigns service to the default service account
+      service_account,
+      # whether the service is serving requests is controlled at the application level
+      serving_status
     ]
   }
 }

--- a/terraform/linode.tf
+++ b/terraform/linode.tf
@@ -35,14 +35,14 @@ module "k8s" {
     "rclone",
   ]
   secrets = {
-    # CSI-Rclone credentials: csi-rclone implements persistent volumes on S3
+    # CSI-Rclone credentials: csi-rclone implements persistent volumes on Backblaze B2
     "rclone" = {
       name      = "rclone-secret"
       namespace = "csi-rclone"
       data = {
         "remote"               = "s3",
         "s3-provider"          = "Other", # any other S3 compatible provider
-        "s3-endpoint"          = local.b2_endpoint,
+        "s3-endpoint"          = "https://${local.b2_endpoint}"
         "s3-access-key-id"     = b2_application_key.k8s_csi.application_key_id, #gitleaks:allow
         "s3-secret-access-key" = b2_application_key.k8s_csi.application_key,    #gitleaks:allow
       }

--- a/terraform/linode.tf
+++ b/terraform/linode.tf
@@ -33,6 +33,7 @@ module "k8s" {
 
   secret_keys = [
     "rclone",
+    "loki-s3",
   ]
   secrets = {
     # CSI-Rclone credentials: csi-rclone implements persistent volumes on Backblaze B2
@@ -45,6 +46,16 @@ module "k8s" {
         "s3-endpoint"          = "https://${local.b2_endpoint}"
         "s3-access-key-id"     = b2_application_key.k8s_csi.application_key_id, #gitleaks:allow
         "s3-secret-access-key" = b2_application_key.k8s_csi.application_key,    #gitleaks:allow
+      }
+    },
+    "loki-s3" = {
+      name      = "loki-s3-credentials"
+      namespace = "monitoring"
+      data = {
+        "S3_ENDPOINT"          = local.b2_endpoint,
+        "S3_ACCESS_KEY_ID"     = b2_application_key.k8s_loki.application_key_id, #gitleaks:allow
+        "S3_SECRET_ACCESS_KEY" = b2_application_key.k8s_loki.application_key,    #gitleaks:allow
+        "LOKI_LOG_BUCKET"      = b2_bucket.logs.bucket_name,
       }
     },
   }

--- a/terraform/linode.tf
+++ b/terraform/linode.tf
@@ -31,10 +31,21 @@ module "k8s" {
     "${local.domain_slug}-tls" = module.tls_cert.private_key,
   }
 
-  # Configure S3 CSI to provision volumes backed by B2 buckets
-  s3_csi = {
-    access_key    = b2_application_key.k8s_csi.application_key    #gitleaks:allow
-    access_key_id = b2_application_key.k8s_csi.application_key_id #gitleaks:allow
-    s3_endpoint   = local.b2_endpoint
+  secret_keys = [
+    "rclone",
+  ]
+  secrets = {
+    # CSI-Rclone credentials: csi-rclone implements persistent volumes on S3
+    "rclone" = {
+      name      = "rclone-secret"
+      namespace = "csi-rclone"
+      data = {
+        "remote"               = "s3",
+        "s3-provider"          = "Other", # any other S3 compatible provider
+        "s3-endpoint"          = local.b2_endpoint,
+        "s3-access-key-id"     = b2_application_key.k8s_csi.application_key_id, #gitleaks:allow
+        "s3-secret-access-key" = b2_application_key.k8s_csi.application_key,    #gitleaks:allow
+      }
+    },
   }
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -73,7 +73,7 @@ resource "b2_bucket" "media" {
   bucket_name = "${local.domain_slug}-media"
   bucket_type = "allPrivate"
 }
-# bucket for storing logs for Monitoring (Loki)
+# bucket for storing logs (Loki)
 resource "b2_bucket" "logs" {
   bucket_name = "${local.domain_slug}-logs"
   bucket_type = "allPrivate"
@@ -84,6 +84,19 @@ resource "b2_application_key" "k8s_csi" {
   capabilities = [
     "readBuckets",
     "writeBuckets",
+    "listFiles",
+    "readFiles",
+    "shareFiles",
+    "writeFiles",
+    "deleteFiles",
+  ]
+}
+# App Key to auth Loki for persisting logs
+resource "b2_application_key" "k8s_loki" {
+  key_name  = "k8s-loki"
+  bucket_id = b2_bucket.logs.id
+  capabilities = [
+    "readBuckets",
     "listFiles",
     "readFiles",
     "shareFiles",

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -73,6 +73,11 @@ resource "b2_bucket" "media" {
   bucket_name = "${local.domain_slug}-media"
   bucket_type = "allPrivate"
 }
+# bucket for storing logs for Monitoring (Loki)
+resource "b2_bucket" "logs" {
+  bucket_name = "${local.domain_slug}-logs"
+  bucket_type = "allPrivate"
+}
 # App Key to auth S3 CSI for provisioning B2 Bucket backed K8s Persistent Volumes
 resource "b2_application_key" "k8s_csi" {
   key_name = "k8s-csi"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -79,11 +79,9 @@ resource "b2_bucket" "logs" {
   bucket_type = "allPrivate"
 }
 # App Key to auth S3 CSI for provisioning B2 Bucket backed K8s Persistent Volumes
-resource "b2_application_key" "k8s_csi" {
-  key_name = "k8s-csi"
-  capabilities = [
+locals {
+  b2_capabilities = [
     "readBuckets",
-    "writeBuckets",
     "listFiles",
     "readFiles",
     "shareFiles",
@@ -91,16 +89,13 @@ resource "b2_application_key" "k8s_csi" {
     "deleteFiles",
   ]
 }
+resource "b2_application_key" "k8s_csi" {
+  key_name     = "k8s-csi"
+  capabilities = concat(local.b2_capabilities, ["writeBuckets"])
+}
 # App Key to auth Loki for persisting logs
 resource "b2_application_key" "k8s_loki" {
-  key_name  = "k8s-loki"
-  bucket_id = b2_bucket.logs.id
-  capabilities = [
-    "readBuckets",
-    "listFiles",
-    "readFiles",
-    "shareFiles",
-    "writeFiles",
-    "deleteFiles",
-  ]
+  key_name     = "k8s-loki"
+  bucket_id    = b2_bucket.logs.id
+  capabilities = local.b2_capabilities
 }

--- a/terraform/modules/linode/k8s/main.tf
+++ b/terraform/modules/linode/k8s/main.tf
@@ -53,9 +53,7 @@ data "kubernetes_service" "ingress" {
 # TLS
 resource "kubernetes_secret" "tls" {
   for_each = var.tls_certs
-
-  type = "kubernetes.io/tls"
-
+  type     = "kubernetes.io/tls"
   metadata {
     name = each.key
     # default to the 'default' k8s namespace if unspecified
@@ -67,18 +65,12 @@ resource "kubernetes_secret" "tls" {
     "tls.key" = var.tls_keys[each.key],
   }
 }
-# CSI-Rclone credentials: csi-rclone implements persistent volumes on S3
-resource "kubernetes_secret" "csi-rclone" {
+# Opaque
+resource "kubernetes_secret" "opaque" {
+  for_each = toset(var.secret_keys)
   metadata {
-    name      = "rclone-secret"
-    namespace = "csi-rclone"
+    name      = var.secrets[each.value].name
+    namespace = var.secrets[each.value].namespace
   }
-
-  data = {
-    "remote"               = "s3",
-    "s3-provider"          = "Other", # any other S3 compatible provider
-    "s3-endpoint"          = var.s3_csi.s3_endpoint,
-    "s3-access-key-id"     = var.s3_csi.access_key_id,
-    "s3-secret-access-key" = var.s3_csi.access_key,
-  }
+  data = var.secrets[each.value].data
 }

--- a/terraform/modules/linode/k8s/variables.tf
+++ b/terraform/modules/linode/k8s/variables.tf
@@ -60,6 +60,6 @@ variable "secrets" {
     data      = map(string)
   }))
   sensitive   = true
-  description = "Map of key (set in 'secret_keys') to K8s Opaque Secrets create on the K8s Cluster."
+  description = "Map of key (set in 'secret_keys') to K8s Opaque Secrets, to create on the K8s Cluster."
   default     = {}
 }

--- a/terraform/modules/linode/k8s/variables.tf
+++ b/terraform/modules/linode/k8s/variables.tf
@@ -48,18 +48,18 @@ variable "tls_keys" {
   EOF
 }
 
-variable "s3_csi" {
-  type = object({
-    s3_endpoint   = string,
-    access_key_id = string,
-    access_key    = string,
-  })
-  sensitive   = true
-  default     = null
-  description = <<EOF
-    Credentials to pass to S3 CSI to provision Persistent Volumes on S3-compatible storage.
+variable "secret_keys" {
+  type        = set(string)
+  description = "Keys used to identify secrets specified in 'secrets' var."
+}
 
-    Passes the given config & credentials to the S3 CSI by applying a 'csi-s3-secret'
-    K8s Secret on the 'kube-system' namespace in the K8s Cluster.
-  EOF
+variable "secrets" {
+  type = map(object({
+    name      = string,
+    namespace = string,
+    data      = map(string)
+  }))
+  sensitive   = true
+  description = "Map of key (set in 'secret_keys') to K8s Opaque Secrets create on the K8s Cluster."
+  default     = {}
 }

--- a/terraform/moved.tf
+++ b/terraform/moved.tf
@@ -4,7 +4,7 @@
 # Moved Tombstones
 #
 
-# Tombstones for resources moved into child modules
+# Tombstones for moved resources
 moved {
   from = google_compute_disk.warp_disk
   to   = module.warp_vm.google_compute_disk.warp_disk
@@ -23,4 +23,9 @@ moved {
 moved {
   from = module.gce.google_compute_network.sandbox
   to   = module.vpc.google_compute_network.sandbox
+}
+
+moved {
+  from = module.k8s.kubernetes_secret.csi-rclone
+  to   = module.k8s.kubernetes_secret.opaque["rclone"]
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -55,8 +55,8 @@ variable "gcp_service_account_key" {
 variable "acme_server_url" {
   type        = string
   description = "URL of the ACME server to use to obtain TLS certificates from."
-  # defaults to Lets Encrypt staging which issues self-signed test certificates.
-  default = "https://acme-staging-v02.api.letsencrypt.org/directory"
+  # use LetsEncrypt's production server to issue trusted TLS certificates
+  default = "https://acme-v02.api.letsencrypt.org/directory"
 }
 
 variable "proxy_gae_tag" {


### PR DESCRIPTION
# Purpose
Lack of K8s cluster observability makes it hard to debug the distributed services deployed on the cluster.

# Contents
Deploy Prometheus, Grafana & Loki for Monitoring / Logging:
- deploy Promethues to scrape metrics & send alerts
- deploy Grafana to visualise metrics & logs on dashboards.
- deploy Loki to aggregate logs & `promtail` as log collector & B2 bucket as data store.
- deploy K8s Metrics Server to collect metrics `kubectl top`

Refactor:
- Linode k8s module to accept generic secrets.
- Make deploying with ACME's Production issue the default in `variables.tf`


Chores:
- configure renovate to upgrade ingress-nginx.