### PR TITLE
feat(terraform): Make deploying WARP VM's Proxy Configurable

### DIFF
--- a/.github/workflows/apply-terraform.yaml
+++ b/.github/workflows/apply-terraform.yaml
@@ -88,4 +88,4 @@ jobs:
           -auto-approve=true
           -var="warp_machine_type=$(
             echo '${{ github.event.inputs.warp_vm_machine_type }}' | cut -d ' ' -f 1 -n
-          )"kjk
+          )"

--- a/.github/workflows/apply-terraform.yaml
+++ b/.github/workflows/apply-terraform.yaml
@@ -14,6 +14,16 @@ on:
         type: boolean
         description: "WARP VM: Deploy?"
         required: true
+      warp_vm_enable_proxy:
+        type: boolean
+        description: "WARP VM: Enable Proxy?"
+        required: true
+      # list of comma separate ports to open on warp vm for development purposes
+      warp_vm_allow_ports:
+        type: string
+        description: "WARP VM: Comma-separated ports to expose"
+        required: false
+        default: ""
       # warp vm machine type setting to control cpu, ram & cost of deployed vm
       warp_vm_machine_type:
         type: choice
@@ -27,6 +37,7 @@ on:
           - "e2-standard-2 - 2CPU, 8GB"
           - "e2-standard-4 - 4CPU, 16GB"
           - "e2-standard-8 - 8CPU, 32GB"
+      # whether to enable warp vm's proxy
       # set vm image used to start warp vm
       warp_vm_image:
         type: choice
@@ -35,12 +46,6 @@ on:
         options:
           - "warp-box"
           - "warp-box-dev"
-      # list of comma separate ports to open on warp vm for development purposes
-      warp_vm_allow_ports:
-        type: string
-        description: "WARP VM: Comma-separated ports to expose"
-        required: false
-        default: ""
       # whether to enable warp vm's http web terminal
       warp_vm_http_term:
         type: boolean
@@ -53,12 +58,6 @@ on:
         required: true
         # by default, allow traffic from all ip addresses
         default: "0.0.0.0/0"
-      # whether to enable warp vm's proxy
-      warp_vm_enable_proxy:
-        type: boolean
-        description: "WARP VM: Enable Proxy?"
-        required: true
-
 jobs:
   apply-terraform:
     name: "Apply Terraform deployment"
@@ -89,4 +88,4 @@ jobs:
           -auto-approve=true
           -var="warp_machine_type=$(
             echo '${{ github.event.inputs.warp_vm_machine_type }}' | cut -d ' ' -f 1 -n
-          )"
+          )"kjk

--- a/.github/workflows/apply-terraform.yaml
+++ b/.github/workflows/apply-terraform.yaml
@@ -53,6 +53,11 @@ on:
         required: true
         # by default, allow traffic from all ip addresses
         default: "0.0.0.0/0"
+      # whether to enable warp vm's proxy
+      warp_vm_enable_proxy:
+        type: boolean
+        description: "WARP VM: Enable Proxy?"
+        required: true
 
 jobs:
   apply-terraform:
@@ -78,6 +83,7 @@ jobs:
           TF_VAR_warp_allow_ports: "${{ github.event.inputs.warp_vm_allow_ports }}"
           TF_VAR_warp_http_terminal: "${{ github.event.inputs.warp_vm_http_term }}"
           TF_VAR_warp_allow_ip: "${{ github.event.inputs.warp_vm_allow_ip }}"
+          TF_VAR_has_warp_proxy: "${{ github.event.inputs.warp_vm_enable_proxy }}"
         run: >
           terraform apply
           -auto-approve=true

--- a/.github/workflows/apply-terraform.yaml
+++ b/.github/workflows/apply-terraform.yaml
@@ -14,6 +14,7 @@ on:
         type: boolean
         description: "WARP VM: Deploy?"
         required: true
+      # whether to enable warp vm's proxy
       warp_vm_enable_proxy:
         type: boolean
         description: "WARP VM: Enable Proxy?"
@@ -37,7 +38,6 @@ on:
           - "e2-standard-2 - 2CPU, 8GB"
           - "e2-standard-4 - 4CPU, 16GB"
           - "e2-standard-8 - 8CPU, 32GB"
-      # whether to enable warp vm's proxy
       # set vm image used to start warp vm
       warp_vm_image:
         type: choice

--- a/terraform/gcp.tf
+++ b/terraform/gcp.tf
@@ -120,7 +120,7 @@ resource "google_app_engine_application" "warp_proxy" {
   project     = local.gcp_project_id
   location_id = local.gcp_region
   # only enable proxy if warp VM is also enabled
-  serving_status = var.has_warp_vm ? "SERVING" : "USER_DISABLED"
+  serving_status = (var.has_warp_vm && var.has_warp_proxy) ? "SERVING" : "USER_DISABLED"
 }
 resource "google_app_engine_flexible_app_version" "warp_proxy_v1" {
   version_id                = "v1"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -46,6 +46,12 @@ variable "warp_allow_ports" {
   default     = ""
 }
 
+variable "has_warp_proxy" {
+  type        = bool
+  description = "Whether to deploy a proxy on Google App Engine to proxy WARP VM."
+  default     = true
+}
+
 variable "gcp_service_account_key" {
   type        = string
   sensitive   = true


### PR DESCRIPTION
# Purpose
WARP's proxy, running on Google App Engine, costs almost as much to run as the WARP VM instance itself.
- Allow users to choose not deploy WARP's proxy if not needed to save on costs.

# Contents
Make deploying WARP VM's Proxy Configurable:
- add checkbox to apply-terraform Workflow input to allow users to chose whether they proxy deployed.
- only deploy WARP VM's proxy with both the checkbox & WARP VM itself is deployed.
