### PR TITLE
feat(k8s): Deploy calibre-web on LKE

### DIFF
--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -16,6 +16,8 @@ resources:
   - ./csi-rclone
   # Monitoring: Prometheus, Grafana
   - ./monitor
+  # EBook Library: Calibre Web
+  - ./library
 
 helmCharts:
   # Authentication: OAuth2 Proxy

--- a/k8s/base/library/deployment.yaml
+++ b/k8s/base/library/deployment.yaml
@@ -1,6 +1,6 @@
 #
 # Nimbus
-# K8s Deployment
+# Library Service
 # Calibre Web Deployment
 #
 
@@ -34,4 +34,4 @@ spec:
             claimName: calibre-web-settings
         - name: library
           persistentVolumeClaim:
-            claimName: calibre-library
+            claimName: library-data

--- a/k8s/base/library/deployment.yaml
+++ b/k8s/base/library/deployment.yaml
@@ -1,0 +1,37 @@
+#
+# Nimbus
+# K8s Deployment
+# Calibre Web Deployment
+#
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: calibre-web
+spec:
+  replicas: 1
+  selector: {} # to be templated by kustomize
+  template:
+    spec:
+      containers:
+      - name: calibre-web
+        image: lscr.io/linuxserver/calibre-web:latest
+        env:
+          # pull calibre tools on startup (eg. ebook-convert command)
+          - name: DOCKER_MODS
+            value: linuxserver/mods:universal-calibre
+        volumeMounts:
+          - mountPath: /config
+            name: settings
+          - mountPath: /books
+            name: library
+        ports:
+          - containerPort: 8083
+            name: http
+      volumes:
+        - name: settings
+          persistentVolumeClaim:
+            claimName: calibre-web-settings
+        - name: library
+          persistentVolumeClaim:
+            claimName: calibre-library

--- a/k8s/base/library/deployment.yaml
+++ b/k8s/base/library/deployment.yaml
@@ -34,4 +34,4 @@ spec:
             claimName: calibre-web-settings
         - name: library
           persistentVolumeClaim:
-            claimName: library-data
+            claimName: data

--- a/k8s/base/library/kustomization.yaml
+++ b/k8s/base/library/kustomization.yaml
@@ -1,0 +1,13 @@
+#
+# Nimbus
+# K8s Deployment
+# Library Service
+#
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+resources:
+- deployment.yaml
+commonLabels:
+    app.kubernetes.io/part-of: library
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: kustomize

--- a/k8s/base/library/kustomization.yaml
+++ b/k8s/base/library/kustomization.yaml
@@ -18,11 +18,11 @@ commonLabels:
 replacements:
   - source:
       kind: PersistentVolumeClaim
-      name: calibre-library
+      name: library-data
       fieldPath: spec.resources.requests.storage
     targets:
       - select:
           kind: PersistentVolume
-          name: calibre-library
+          name: library-data
         fieldPaths:
           - spec.capacity.storage

--- a/k8s/base/library/kustomization.yaml
+++ b/k8s/base/library/kustomization.yaml
@@ -5,6 +5,7 @@
 #
 
 apiVersion: kustomize.config.k8s.io/v1beta1
+namePrefix: library-
 resources:
 - library-pv.yaml
 - library-pvc.yaml

--- a/k8s/base/library/kustomization.yaml
+++ b/k8s/base/library/kustomization.yaml
@@ -6,8 +6,23 @@
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 resources:
+- library-pv.yaml
+- library-pvc.yaml
+- settings-pvc.yaml
 - deployment.yaml
 commonLabels:
     app.kubernetes.io/part-of: library
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: kustomize
+# match calibre library PV's declared capacity to the size requested by the PVC
+replacements:
+  - source:
+      kind: PersistentVolumeClaim
+      name: calibre-library
+      fieldPath: spec.resources.requests.storage
+    targets:
+      - select:
+          kind: PersistentVolume
+          name: calibre-library
+        fieldPaths:
+          - spec.capacity.storage

--- a/k8s/base/library/kustomization.yaml
+++ b/k8s/base/library/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
 - library-pvc.yaml
 - settings-pvc.yaml
 - deployment.yaml
+- service.yaml
 commonLabels:
     app.kubernetes.io/part-of: library
     app.kubernetes.io/managed-by: kustomize

--- a/k8s/base/library/library-pv.yaml
+++ b/k8s/base/library/library-pv.yaml
@@ -1,15 +1,15 @@
 #
 # Nimbus
-# Calibre Web Deployment
+# Library Service
 # Library Persistent Volume
 #
 
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: calibre-library
+  name: library-data
   labels:
-    stores: calibre-library
+    stores: library-data
 spec:
   accessModes:
   - ReadWriteMany

--- a/k8s/base/library/library-pv.yaml
+++ b/k8s/base/library/library-pv.yaml
@@ -7,7 +7,7 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: library-data
+  name: data
   labels:
     stores: library-data
 spec:

--- a/k8s/base/library/library-pv.yaml
+++ b/k8s/base/library/library-pv.yaml
@@ -1,0 +1,21 @@
+#
+# Nimbus
+# Calibre Web Deployment
+# Library Persistent Volume
+#
+
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: calibre-library
+  labels:
+    stores: calibre-library
+spec:
+  accessModes:
+  - ReadWriteMany
+  capacity:
+    storage: "" # matches PVC storage requests
+  storageClassName: rclone
+  csi:
+    driver: csi-rclone
+    volumeHandle: ecfd06f6-ea6b-46ea-ab50-493d033a2e17

--- a/k8s/base/library/library-pvc.yaml
+++ b/k8s/base/library/library-pvc.yaml
@@ -1,0 +1,20 @@
+#
+# Nimbus
+# Calibre Web Deployment
+# Library Persistent Volume Claim
+#
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: calibre-library
+spec:
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: rclone
+  selector:
+    matchLabels:
+      stores: calibre-library

--- a/k8s/base/library/library-pvc.yaml
+++ b/k8s/base/library/library-pvc.yaml
@@ -7,7 +7,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: library-data
+  name: data
 spec:
   accessModes:
   - ReadWriteMany

--- a/k8s/base/library/library-pvc.yaml
+++ b/k8s/base/library/library-pvc.yaml
@@ -1,6 +1,6 @@
 #
 # Nimbus
-# Calibre Web Deployment
+# Library Service
 # Library Persistent Volume Claim
 #
 

--- a/k8s/base/library/library-pvc.yaml
+++ b/k8s/base/library/library-pvc.yaml
@@ -7,7 +7,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: calibre-library
+  name: library-data
 spec:
   accessModes:
   - ReadWriteMany
@@ -17,4 +17,4 @@ spec:
   storageClassName: rclone
   selector:
     matchLabels:
-      stores: calibre-library
+      stores: library-data

--- a/k8s/base/library/service.yaml
+++ b/k8s/base/library/service.yaml
@@ -1,0 +1,17 @@
+#
+# Nimbus
+# Library Service
+# k8s Service
+#
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: calibre-web
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: http

--- a/k8s/base/library/settings-pvc.yaml
+++ b/k8s/base/library/settings-pvc.yaml
@@ -1,0 +1,16 @@
+#
+# Nimbus
+# Calibre Web Deployment
+# Settings Persistent Volume Claim
+#
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: calibre-web-settings
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi

--- a/k8s/lke/ingress/calibre-web.yaml
+++ b/k8s/lke/ingress/calibre-web.yaml
@@ -1,0 +1,33 @@
+#
+# Nimbus
+# Library Service
+# Calibre Web Ingress
+#
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: library-calibre-web
+  labels:
+    app.kubernetes.io/part-of: library
+  annotations:
+    nginx.ingress.kubernetes.io/auth-url: "https://auth.mrzzy.co/oauth2/auth"
+    nginx.ingress.kubernetes.io/auth-signin: "https://auth.mrzzy.co/oauth2/start?rd=$scheme://$host$escaped_request_uri"
+    nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-Email, X-Auth-Request-User"
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: library.mrzzy.co
+    http:
+      paths:
+      - backend:
+          service:
+            name: library-calibre-web
+            port:
+              number: 80
+        path: /
+        pathType: Prefix
+  tls:
+  - hosts:
+    - library.mrzzy.co
+    secretName: mrzzy-co-tls

--- a/k8s/lke/ingress/kustomization.yaml
+++ b/k8s/lke/ingress/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - flood.yaml
   - jellyfin.yaml
   - grafana.yaml
+  - calibre-web.yaml
 commonLabels:
   app.kubernetes.io/managed-by: kustomize
   app.kubernetes.io/created-by: kustomize

--- a/k8s/lke/kustomization.yaml
+++ b/k8s/lke/kustomization.yaml
@@ -15,7 +15,7 @@ secretGenerator:
     behavior: replace
     # unset env vars in env file will be read from the execution environment
     # https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/#configmapgenerator
-    env: oauth2-proxy/.secret.env
+    env: oauth2-proxy/secret.env
 
 configMapGenerator:
   - name: login-oauth2-proxy

--- a/k8s/lke/kustomization.yaml
+++ b/k8s/lke/kustomization.yaml
@@ -15,7 +15,7 @@ secretGenerator:
     behavior: replace
     # unset env vars in env file will be read from the execution environment
     # https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/#configmapgenerator
-    env: oauth2-proxy/secret.env
+    env: oauth2-proxy/.secret.env
 
 configMapGenerator:
   - name: login-oauth2-proxy
@@ -27,9 +27,10 @@ configMapGenerator:
       - restricted_user_access=oauth2-proxy/authenticated_emails_file
 
 patches:
-  - media/patch-pv.yaml
-  - oauth2-proxy/patch-deployment.yaml
-  - oauth2-proxy/patch-ingress.yaml
+  - path: media/patch-pv.yaml
+  - path: library/patch-pv.yaml
+  - path: oauth2-proxy/patch-deployment.yaml
+  - path: oauth2-proxy/patch-ingress.yaml
 
 patchesJson6902:
   # patch Metrics Server to disable TLS when scraping Linode worker's kubelet as

--- a/k8s/lke/library/patch-pv.yaml
+++ b/k8s/lke/library/patch-pv.yaml
@@ -1,0 +1,16 @@
+#
+# Nimbus
+# Library Service
+# Persistent Volume Patch
+#
+
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: library-data
+spec:
+  csi:
+    volumeAttributes:
+      remotePath: mrzzy-co-library
+      # vfs performance: disable modefile
+      no-modtime: "true"

--- a/terraform/cloudflare.tf
+++ b/terraform/cloudflare.tf
@@ -23,6 +23,7 @@ module "dns" {
     "auth" : module.k8s.ingress_ip,    # oauth2-proxy oauth callbacks / login page
     "media" : module.k8s.ingress_ip,   # jellyfin media server
     "monitor" : module.k8s.ingress_ip, # Grafana monitoring
+    "library" : module.k8s.ingress_ip, # Ebook Library
     },
     # only create dns route for WARP VM if its deployed
     var.has_warp_vm ? { "warp" : local.warp_ip } : {},

--- a/terraform/cloudflare.tf
+++ b/terraform/cloudflare.tf
@@ -23,7 +23,7 @@ module "dns" {
     "auth" : module.k8s.ingress_ip,    # oauth2-proxy oauth callbacks / login page
     "media" : module.k8s.ingress_ip,   # jellyfin media server
     "monitor" : module.k8s.ingress_ip, # Grafana monitoring
-    "library" : module.k8s.ingress_ip, # Ebook Library
+    "library" : module.k8s.ingress_ip, # EBook Library
     },
     # only create dns route for WARP VM if its deployed
     var.has_warp_vm ? { "warp" : local.warp_ip } : {},


### PR DESCRIPTION
# Motivation
Cloud-based personal documents, Ebooks library that is not tied to one device.

# Contents
Deploy [calibre-web](https://github.com/janeczku/calibre-web) on Linode LKE, exposed via ingress on the `library.mrzzy.co` DNS route.