### PR TITLE
refactor(proxy-gae): Switch to host based routing

### DIFF
--- a/.github/workflows/apply-terraform.yaml
+++ b/.github/workflows/apply-terraform.yaml
@@ -18,7 +18,7 @@ on:
         type: string
         description: "GAE Proxy: Routes"
         required: true
-        default: "/warp=https://warp.mrzzy.co "
+        default: "warp=https://warp.mrzzy.co "
 
       # WARP VM inputs
       # setting: whether to deploy the warp vm

--- a/docker/proxy-gae/nginx.conf.jinja2
+++ b/docker/proxy-gae/nginx.conf.jinja2
@@ -13,8 +13,35 @@ http {
     # Logs will appear on the Google Developer's Console when logged to this directory.
     access_log /var/log/app_engine/app.log;
     error_log /var/log/app_engine/app.log;
-    # use docker's default nameserver to resolve DNS
+    # dns nameservers
     resolver {{ nameservers }};
+
+    # proxy routes
+    {%- for host, target in proxy_spec.items() %}
+    # {{ host }} -> {{ target }}
+    server {
+        # Google App Engine expects the runtime to serve HTTP traffic from port 8080.
+        listen 8080;
+        server_name {{ host }};
+
+        location / {
+            # force dns resolution at runtime by pass target url as nginx var to proxy_pass
+            set $target_url {{ target }};
+            # when variables are used with proxy_pass, the request URL must be explicitly passed.
+            proxy_pass $target_url;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Host $host;
+
+            # proxy directives needed for proxying websocket connections
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_read_timeout 300s; # wait 5mins before closing websockets
+        }
+    }
+    {%- endfor %}
+
 
     server {
         # Google App Engine expects the runtime to serve HTTP traffic from port 8080.
@@ -26,38 +53,6 @@ http {
         location = /health {
             return 200 ok;
         }
-
-        # proxy routes
-        {%- for route, target in proxy_spec.items() %}
-        # /{{ route }} -> {{ target }}
-        # redirect to route with trailing slash if request omits it
-        {% if route != "" %}
-        location = {{ route }} {
-            # handle case where we are running behind a proxy by using
-            # the original hostname the user connected to from the X-Forwarded-Host header
-            if ($http_x_forwarded_host) {
-                return 301 $scheme://$http_x_forwarded_host{{ route }}/;
-            }
-            return 301 {{ route }}/;
-        }
-        {% endif %}
-        location {{ route }}/ {
-            # force dns resolution at runtime by pass target url as nginx var to proxy_pass
-            set $target_url {{ target }};
-            # strip route prefix from request url
-            rewrite {{ route }}/(.*) /$1 break;
-            # when variables are used with proxy_pass, the request URL must be explicitly passed.
-            proxy_pass $target_url;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-
-            # proxy directives needed for proxying websocket connections
-            proxy_http_version 1.1;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection "upgrade";
-            proxy_read_timeout 300s; # wait 5mins before closing websockets
-        }
-        {%- endfor %}
     }
 }
 # vim: ft=nginx.jinja2

--- a/docker/proxy-gae/template.py
+++ b/docker/proxy-gae/template.py
@@ -19,9 +19,9 @@ def parse_proxy(spec_str: str) -> Dict[str, str]:
     # strip trailing '/' for standardization
     spec = dict([(route.rstrip("/"), target.rstrip("/")) for route, target in specs])
 
-    # check: no reserved routes
-    if "/health" in spec:
-        raise ValueError("'/health' route is reserved for health checks.")
+    # check: no empty hosts
+    if "" in spec:
+        raise ValueError("Proxy specs with no host are not supported.")
 
     return spec
 
@@ -33,10 +33,10 @@ if __name__ == "__main__":
         "proxy_spec",
         type=parse_proxy,
         help=dedent(
-            """Specify routes that should be proxied in the format:
-            '/<ROUTE>=<TARGET> [/<ROUTE>=<TARGET2> ...]'
-            Example: '/proxy=https://proxy.me' will proxy all requests sent to
-            '/proxy/target/url' to 'https://proxy.me/target/url'
+            """Specify hosts that should be proxied in the format:
+            '<HOST>=<TARGET> [<HOST>=<TARGET2> ...]'
+            Example: 'proxy.host=https://target.host' will proxy all requests sent to
+            'proxy.host/target/url' to 'https://target.host/target/url'
             """
         ),
     )
@@ -54,6 +54,5 @@ if __name__ == "__main__":
         proxy_spec=args.proxy_spec,
         nameservers=" ".join(Resolver().nameservers),
     )
-
     with open(args.output_path, "w") as f:
         f.write(nginx_conf)

--- a/docker/proxy-gae/test/docker-compose.yaml
+++ b/docker/proxy-gae/test/docker-compose.yaml
@@ -9,8 +9,8 @@ services:
     build: ..
     ports: ["8080:8080"]
     environment:
-      # multiple proxy routes to the same target
-      PROXY_SPEC: "/target=http://target /alternate=http://target"
+      # multiple proxy hosts to the same target
+      PROXY_SPEC: "target=http://target alt.target=http://target"
 
   target:
     image: nginx:1.23.2-alpine


### PR DESCRIPTION
# Purpose
Fixes #233

# Contents
Switches proxy-gae to host based routing:
- test(proxy-gae): update e2e test to host based routing
- feat(proxy-gae): implement host based proxy routing
- ci(terraform): update default proxy spec template to host based routes
