### PR TITLE
feat(terraform): Deploy AWS S3 & Redshift Serverless Lake & Warehouse

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 Self-hosted services in the Cloud.
 
 ## Introduction
-Nimbus centralises Infrastructure (eg. Terraform deployments, Kubernetes Manifests & Docker Containers) that deploys self-hosted services on multiple Cloud Platforms in one repository.
+Nimbus centralises Infrastructure (eg. Terraform deployments, Kubernetes Manifests & Docker Containers) that deploys self-hosted services on Cloud Platforms in one repository.
 
 ## Features
 - **Economies of Scale**  Cross-cutting concerns between Self-hosted services (eg. Logging, Monitoring, CDN Caching & DNS) can be fulfilled via a set of shared services that only need to be deployed once.
 - **Infrastructure as Code (IaC)** Expressing IaC makes infrastructure dynamic & malleable to changes. Dependencies between Multiple Cloud providers can be expressed explicitly in code. Checking IaC into Git provides checkpoints for rollbacks if something goes wrong.
-
+- **Multi Cloud** Consolidates deployments on multiple Cloud Platforms (AWS, GCP, Cloudflare &amp; Blackblaze) in one place.
 
 ## Architecture
 ```mermaid
@@ -50,6 +50,11 @@ flowchart LR
                 airflow[Airflow]
             end
         end
+    end
+
+    subgraph aws[Amazon Web Services]
+        direction LR
+        s3[(S3 Data Lake)] --> redshift[(Redshift Serverless)]
     end
 ```
 

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -52,6 +52,29 @@ provider "registry.terraform.io/cloudflare/cloudflare" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.60.0"
+  constraints = "4.60.0"
+  hashes = [
+    "h1:b2U4EncUaHCsQuiePo/yHZiH5ib0rx+P/qG4LC8pGlA=",
+    "zh:1853d6bc89e289ac36c13485e8ff877c1be8485e22f545bb32c7a30f1d1856e8",
+    "zh:4321d145969e3b7ede62fe51bee248a15fe398643f21df9541eef85526bf3641",
+    "zh:4c01189cc6963abfe724e6b289a7c06d2de9c395011d8d54efa8fe1aac444e2e",
+    "zh:5934db7baa2eec0f9acb9c7f1c3dd3b3fe1e67e23dd4a49e9fe327832967b32b",
+    "zh:5fbedf5d55c6e04e34c32b744151e514a80308e7dec633a56b852829b41e4b5a",
+    "zh:651558e1446cc05061b75e6f5cc6e2959feb17615cd0ace6ec7a2bcc846321c0",
+    "zh:76875eb697916475e554af080f9d4d3cd1f7d5d58ecdd3317a844a30980f4eec",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a52528e6d6c945a6ac45b89e9a70a5435148e4c151241e04c231dd2acc4a8c80",
+    "zh:af5f94c69025f1c2466a3cf970d1e9bed72938ec33b976c8c067468b6707bb57",
+    "zh:b6692fad956c9d4ef4266519d9ac2ee9f699f8f2c21627625c9ed63814d41590",
+    "zh:b74311af5fa5ac6e4eb159c12cfb380dfe2f5cd8685da2eac8073475f398ae60",
+    "zh:cc5aa6f738baa42edacba5ef1ca0969e5a959422e4491607255f3f6142ba90ed",
+    "zh:dd1a7ff1b22f0036a76bc905a8229ce7ed0a7eb5a783d3a2586fb1bd920515c3",
+    "zh:e5ab40c4ad0f1c7bd4d5d834d1aa144e690d1a93329d73b3d37512715a638de9",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/google" {
   version     = "4.58.0"
   constraints = ">= 3.64.0, >= 4.22.0, < 4.58.1, < 5.0.0"

--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -24,3 +24,42 @@ resource "aws_s3_bucket_public_access_block" "lake" {
   block_public_acls   = true
   block_public_policy = true
 }
+
+# Redshift Serverless Data warehouse
+# iam policy to that allows read access to data lake
+data "aws_iam_policy_document" "allow_lake" {
+  statement {
+    sid = "AllowS3ReadOnlyOnLake"
+    resources = [
+      aws_s3_bucket.lake.arn
+    ]
+    # derived from predefined policy "AmazonS3ReadOnlyAccess"
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+      "s3-object-lambda:Get*",
+      "s3-object-lambda:List*",
+    ]
+  }
+}
+# role to identify redshift when accessing other AWS services (eg. S3)
+resource "aws_iam_role" "warehouse" {
+  name               = "warehouse"
+  assume_role_policy = data.aws_iam_policy_document.allow_lake.json
+}
+# namespace to segeregate our db objects within the redshift serverless
+resource "aws_redshiftserverless_namespace" "warehouse" {
+  namespace_name       = "main"
+  db_name              = "mrzzy"
+  default_iam_role_arn = aws_iam_role.warehouse.arn
+}
+# workgroup of redshift serverless compute resources
+resource "aws_redshiftserverless_workgroup" "warehouse" {
+  namespace_name = aws_redshiftserverless_namespace.warehouse.id
+  workgroup_name = "main"
+  # by default, redshift serverless runs with 128 RPUs, which is overkill.
+  # with our small use case the minimum of 8 RPUs should do.
+  base_capacity = 8
+  # public access needed for querying from GCP over the internet
+  publicly_accessible = true
+}

--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -42,6 +42,14 @@ resource "aws_s3_bucket_policy" "lake_http_only" {
     ]
   })
 }
+# block public access on bucket
+resource "aws_s3_bucket_public_access_block" "lake" {
+  bucket                  = aws_s3_bucket.lake.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
 
 # Redshift Serverless Data Warehouse
 # iam policy to that allows read access to data lake

--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -18,6 +18,30 @@ resource "aws_s3_bucket_ownership_controls" "lake" {
     object_ownership = "BucketOwnerEnforced"
   }
 }
+# enforce strict HTTPS transport on S3 data lake
+resource "aws_s3_bucket_policy" "lake_http_only" {
+  bucket = aws_s3_bucket.lake.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "HTTPSOnly"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:*"
+        Resource = [
+          aws_s3_bucket.lake.arn,
+          "${aws_s3_bucket.lake.arn}/*",
+        ]
+        Condition = {
+          Bool = {
+            "aws:SecureTransport" = "false"
+          }
+        }
+      },
+    ]
+  })
+}
 
 # Redshift Serverless Data Warehouse
 # iam policy to that allows read access to data lake

--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -18,12 +18,6 @@ resource "aws_s3_bucket_ownership_controls" "lake" {
     object_ownership = "BucketOwnerEnforced"
   }
 }
-# block public access on bucket
-resource "aws_s3_bucket_public_access_block" "lake" {
-  bucket              = aws_s3_bucket.lake.id
-  block_public_acls   = true
-  block_public_policy = true
-}
 
 # Redshift Serverless Data Warehouse
 # iam policy to that allows read access to data lake

--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -25,7 +25,7 @@ resource "aws_s3_bucket_public_access_block" "lake" {
   block_public_policy = true
 }
 
-# Redshift Serverless Data warehouse
+# Redshift Serverless Data Warehouse
 # iam policy to that allows read access to data lake
 data "aws_iam_policy_document" "allow_lake" {
   statement {

--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -66,9 +66,11 @@ resource "aws_iam_role" "warehouse" {
 }
 # namespace to segeregate our db objects within the redshift serverless
 resource "aws_redshiftserverless_namespace" "warehouse" {
-  namespace_name       = "main"
-  db_name              = "mrzzy"
+  namespace_name = "main"
+  db_name        = "mrzzy"
+  # default iam role must also be listed in iam roles
   default_iam_role_arn = aws_iam_role.warehouse.arn
+  iam_roles            = [aws_iam_role.warehouse.arn]
 }
 # workgroup of redshift serverless compute resources
 resource "aws_redshiftserverless_workgroup" "warehouse" {

--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -1,0 +1,26 @@
+#
+# Nimbus
+# AWS Cloud Deployment
+#
+
+provider "aws" {
+  region = "ap-southeast-1" # Singapore
+}
+
+# S3 bucket as a Data Lake
+resource "aws_s3_bucket" "lake" {
+  bucket = "mrzzy-co-data-lake"
+}
+# disable S3 ACLs & grant bucket owner ownership of objects as well
+resource "aws_s3_bucket_ownership_controls" "lake" {
+  bucket = aws_s3_bucket.lake.id
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+# block public access on bucket
+resource "aws_s3_bucket_public_access_block" "lake" {
+  bucket              = aws_s3_bucket.lake.id
+  block_public_acls   = true
+  block_public_policy = true
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -28,6 +28,10 @@ terraform {
       source  = "cloudflare/cloudflare"
       version = "4.2.0"
     }
+    aws = {
+      source  = "hashicorp/aws"
+      version = "4.60.0"
+    }
   }
 
   # terraform cloud workspace to store terraform state


### PR DESCRIPTION
# Purpose
Setup a data lake &amp; data warehouse for the [Providence](https://github.com/mrzzy/providence) data engineering project.

# Contents
Deploys infrastructure on AWS for the [Providence](https://github.com/mrzzy/providence) data engineering project:
- Data Lake: deploy a S3 bucket.
- Data Warehouse: deploy Redshift Serverless Namespace & Workgroup.
- Configure AWS IAM to allow Redshift to access Data Lake S3 bucket.
- Update system design diagram.
