### PR TITLE
ci(rotate-ips): Add GH workflow to rotate proxy IPs daily

### DIFF
--- a/.github/actions/rotate-ip/action.yaml
+++ b/.github/actions/rotate-ip/action.yaml
@@ -1,0 +1,70 @@
+#
+# Nimbus
+# CI
+# Rotate IP Action
+#
+
+name: "Rotate IP"
+description: >-
+  Rotates external IPs of Kubernetes LoadBalancer services by deleting
+  and recreating the service. Propagates changes in IP to DNS records
+  with a 'terraform apply' targeted at DNS records.
+inputs:
+  namespace:
+    description: K8s namespace of the service to be rotated.
+    default: default
+  name:
+    description: Name of the K8s service to be rotated.
+  tf_api_token:
+    description: Terraform API token credentials for authentication with Terraform Cloud.
+  dns_record:
+    description: Fully qualified reference to the Terraform DNS record resource
+      to propagate IP changes to.
+runs:
+  using: composite
+  steps:
+    - name: "Setup kubectl access to GKE"
+      uses: ./.github/actions/setup-gke
+    - name: "Export proxy K8s services"
+      shell: bash
+      run: |
+        set -ex -o pipefail
+        kubectl get service -n ${{ inputs.namespace }} ${{ inputs.name }} -o yaml | \
+        # clean up attributes from k8s services that will hamper their reimport
+        yq 'del(.metadata.annotations.["kubectl.kubernetes.io/last-applied-configuration"]) |
+            del(.status)  |
+            del(.spec.clusterIP) |
+            del(.spec.clusterIPs) |
+            del(.. |
+            select(has("nodePort")) | .nodePort)' > service.yaml
+    - name: "Delete proxy K8s services"
+      shell: bash
+      run: kubectl delete service -n ${{ inputs.namespace }} ${{ inputs.name }}
+    - name: "Reapply Proxy K8s services"
+      shell: bash
+      run: kubectl apply -f service.yaml
+    - name: "Wait for K8s Service external IP"
+      shell: bash
+      run: |
+        set -e -o pipefail
+        wait_external_ip() {
+          while [ -z "$(kubectl get $1 svc/$2 -o=jsonpath='{.status.loadBalancer}' |
+          grep 'Ingress')" ]
+          do
+          echo "Waiting 5 seconds for service $1 to be assigned an external IP."
+          sleep 5
+          done
+        }
+        # wait for services external ip of services to be assigned
+        wait_external_ip ${{ inputs.namespace }} ${{ inputs.name }}
+    - name: "Setup Terraform CLI"
+      uses: hashicorp/setup-terraform@v2
+      with:
+        terraform_version: 1.5.2
+        cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+    - name: "Update DNS records with Rotated IP"
+      shell: bash
+      run: >
+        terraform apply
+        -auto-approve=true
+        -target='${{ inputs.dns_record }}'

--- a/.github/workflows/rotate-ips.yaml
+++ b/.github/workflows/rotate-ips.yaml
@@ -1,0 +1,61 @@
+#
+# Nimbus
+# CI
+# Rotate Proxy IPs
+#
+
+name: "Rotate Proxy IPs"
+on:
+  # UTC 1800 - 2am in SGT
+  schedule: [ cron: "00 18 * * *" ]
+  # manual trigger
+  workflow_dispatch: {}
+jobs:
+  rotate-ips:
+    name: "Rotate Proxy IPs"
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: "Setup kubectl access to GKE"
+        uses: ./.github/actions/setup-gke
+      - name: "Export proxy K8s services"
+        run: |
+          set -ex -o pipefail
+          kubectl get service -n proxy shadowsocks naiveproxy -o yaml | \
+          # clean up attributes from k8s services that will hamper their reimport
+          yq 'del(.metadata.annotations.["kubectl.kubernetes.io/last-applied-configuration"]) |
+              del(.status)  |
+              del(.spec.clusterIP) |
+              del(.spec.clusterIPs) |
+              del(.. |
+              select(has("nodePort")) | .nodePort)' > services.yaml
+      - name: "Delete proxy K8s services"
+        run: |
+          kubectl delete service -n proxy shadowsocks naiveproxy
+      - name: "Reapply Proxy K8s services"
+        run: |
+          wait_external_ip() {
+            while [ -z "$(kubectl get -n proxy -n proxy svc/$1  -o=jsonpath='{.status.loadBalancer}' |
+            grep 'ingress')" ]
+            do
+            echo "Waiting 5 seconds for service $1 to be assigned an external IP."
+            sleep 5
+            done
+          }
+          set -ex -o pipefail
+          kubectl apply -f services.yaml
+
+          # wait for services external ip of services to be assigned
+          wait_external_ip shadowsocks
+          wait_external_ip naiveproxy
+      - name: "Setup Terraform CLI"
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 1.5.2
+          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+      - name: "Update DNS records with Rotated IPs"
+        run: >
+          terraform apply
+          -auto-approve=true
+          -target='module.dns.cloudflare_record.route["naiveproxy"]'
+          -target='module.dns.cloudflare_record.route["shadowsocks"]'

--- a/.github/workflows/rotate-ips.yaml
+++ b/.github/workflows/rotate-ips.yaml
@@ -12,50 +12,20 @@ on:
   workflow_dispatch: {}
 jobs:
   rotate-ips:
-    name: "Rotate Proxy IPs"
+    strategy:
+      fail-fast: false
+      matrix:
+        proxy:
+          - shadowsocks
+          - naiveproxy
+    name: "${{ matrix.proxy }}: Rotate Proxy IP"
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - name: "Setup kubectl access to GKE"
-        uses: ./.github/actions/setup-gke
-      - name: "Export proxy K8s services"
-        run: |
-          set -ex -o pipefail
-          kubectl get service -n proxy shadowsocks naiveproxy -o yaml | \
-          # clean up attributes from k8s services that will hamper their reimport
-          yq 'del(.metadata.annotations.["kubectl.kubernetes.io/last-applied-configuration"]) |
-              del(.status)  |
-              del(.spec.clusterIP) |
-              del(.spec.clusterIPs) |
-              del(.. |
-              select(has("nodePort")) | .nodePort)' > services.yaml
-      - name: "Delete proxy K8s services"
-        run: |
-          kubectl delete service -n proxy shadowsocks naiveproxy
-      - name: "Reapply Proxy K8s services"
-        run: |
-          wait_external_ip() {
-            while [ -z "$(kubectl get -n proxy -n proxy svc/$1  -o=jsonpath='{.status.loadBalancer}' |
-            grep 'ingress')" ]
-            do
-            echo "Waiting 5 seconds for service $1 to be assigned an external IP."
-            sleep 5
-            done
-          }
-          set -ex -o pipefail
-          kubectl apply -f services.yaml
-
-          # wait for services external ip of services to be assigned
-          wait_external_ip shadowsocks
-          wait_external_ip naiveproxy
-      - name: "Setup Terraform CLI"
-        uses: hashicorp/setup-terraform@v2
+      - name: "Rotate Proxy IP"
+        uses: ./.github/actions/rotate-ip
         with:
-          terraform_version: 1.5.2
-          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
-      - name: "Update DNS records with Rotated IPs"
-        run: >
-          terraform apply
-          -auto-approve=true
-          -target='module.dns.cloudflare_record.route["naiveproxy"]'
-          -target='module.dns.cloudflare_record.route["shadowsocks"]'
+          namespace: proxy
+          name: "${{ matrix.proxy }}"
+          tf_api_token: "${{ secrets.TF_API_TOKEN }}"
+          dns_record: 'module.dns.cloudflare_record.route["${{ matrix.proxy }}"]'

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -74,7 +74,7 @@ provider "registry.terraform.io/hashicorp/aws" {
 
 provider "registry.terraform.io/hashicorp/google" {
   version     = "4.72.0"
-  constraints = "< 4.72.1"
+  constraints = ">= 3.64.0, >= 4.22.0, < 4.72.1, < 5.0.0"
   hashes = [
     "h1:03tgqyT7qvJVGb6Lv23QFC+XZwrbRoBxQ7qNNpYgm5Y=",
     "h1:2snj/8F72+Dn4XxVY6Y99EyASc6KnSTkgdHYqUu/FAA=",
@@ -87,6 +87,18 @@ provider "registry.terraform.io/hashicorp/google" {
     "h1:g2Vx+zPJLY8nqcPTb3/+XmWjUbryRxSqXzyeGQa3l7o=",
     "h1:qxkcRkzNEETckfhyZ9Ff+s0rjb9HVq1z7yAVnBIcmjY=",
     "h1:r9AkYoh+gDXyoITP6Td/cARcFkYH5wV5bwuW0yU4OsA=",
+    "zh:0e12fc23ec88df4039f2edda0fd37ca170c0f74c01370430a5327d13a54cf06d",
+    "zh:0e78dfad7be1c7fb2d65590be258aac6c3bf29a86c5f68ab06526a242b5ac119",
+    "zh:55965e79ba41688aadf0f6c5011cabeec87ed4be8bd9f2379398ff5fc09a9bcc",
+    "zh:5e5ffb629b9471e84be34b11685bfd16c3f80aee3179b06bc97b23617380a641",
+    "zh:5f300bfbf3475555362bb3e358360ae10b6ffe7d7360c94964e6b2e420a922e6",
+    "zh:9a911fc34d0b6ac35e78242a990e9864061a4d28967705688bfbc75933a8887f",
+    "zh:9c665d90f1e7dbc163fd28222fc04d6ff941cd1b01997e474dc1d4e03351732d",
+    "zh:a8f1607a38586ee1dd41f89f53afd27997037e1f888d844d8585966bb9981ec6",
+    "zh:c93c118cd457e21ad9d7af003fe94eb76e757143c3a198e013fc530368755506",
+    "zh:cc27227e4db680a521862bd61e34ed433b8c4b27b53c87bdead62ff09b27f155",
+    "zh:d46d25b4c51846ee8276f6d6094c14a6c39a51c57a98534b372486e8e89b1147",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }
 

--- a/terraform/cloudflare.tf
+++ b/terraform/cloudflare.tf
@@ -28,10 +28,10 @@ module "dns" {
     pipelines = { subdomain = "pipelines", value = local.ingress_ip }, # Apache Airflow pipeline ochestrator
     analytics = { subdomain = "analytics", value = local.ingress_ip }, # Apache Superset analytics
     shadowsocks = {
-      subdomain = "ss.p", value = module.gke.exported_ips["proxy::shadowsocks"],
+      subdomain = "ss", value = module.gke.exported_ips["proxy::shadowsocks"],
     },
     naiveproxy = {
-      subdomain = "naive.p", value = module.gke.exported_ips["proxy::naiveproxy"]
+      subdomain = "naive", value = module.gke.exported_ips["proxy::naiveproxy"]
     },
     # dns routes for mrzzy.co mail routing
     mx1    = { type = "MX", subdomain = "@", value = "mx1.simplelogin.co.", priority = 10 },


### PR DESCRIPTION
# Motivation
Proxy IPs might be banned once detected.

# Contents
Add Github Workflow `rotate-ips` to periodically or manually rotate proxy IPs:
- deletes and recreates Proxy's K8s service to rotate ip.
- propagates changes to proxy ips to DNS.
